### PR TITLE
Fix compatibility with latest glue.core.coordinates API

### DIFF
--- a/glue_astronomy/spectral_coordinates.py
+++ b/glue_astronomy/spectral_coordinates.py
@@ -14,6 +14,7 @@ class SpectralCoordinates(Coordinates):
     def __init__(self, values):
         self._index = np.arange(len(values))
         self._values = values
+        super().__init__(n_dim=1)
 
     @property
     def spectral_axis(self):
@@ -23,7 +24,7 @@ class SpectralCoordinates(Coordinates):
         """
         return self._values
 
-    def world2pixel(self, *world):
+    def world_to_pixel_values(self, *world):
         """
         Parameters
         ----------
@@ -34,7 +35,7 @@ class SpectralCoordinates(Coordinates):
         return tuple(np.interp(world, self._values.value, self._index,
                                left=np.nan, right=np.nan))
 
-    def pixel2world(self, *pixel):
+    def pixel_to_world_values(self, *pixel):
         """
         Parameters
         ----------
@@ -44,13 +45,3 @@ class SpectralCoordinates(Coordinates):
         """
         return tuple(np.interp(pixel, self._index, self._values.value,
                                left=np.nan, right=np.nan))
-
-    def dependent_axes(self, axis):
-        """
-        Parameters
-        ----------
-        axis
-        Returns
-        -------
-        """
-        return (axis,)

--- a/glue_astronomy/translators/ccddata.py
+++ b/glue_astronomy/translators/ccddata.py
@@ -1,8 +1,10 @@
 import numpy as np
 
+from astropy.wcs import WCS
+
 from glue.config import data_translator
 from glue.core import Data, Subset
-from glue.core.coordinates import Coordinates, WCSCoordinates
+from glue.core.coordinates import Coordinates
 
 from astropy import units as u
 
@@ -10,14 +12,10 @@ from astropy.nddata import CCDData
 
 
 @data_translator(CCDData)
-class Specutils1DHandler:
+class CCDDataHandler:
 
     def to_data(self, obj):
-        if obj.wcs is None:
-            coords = None
-        else:
-            coords = WCSCoordinates(wcs=obj.wcs)
-        data = Data(coords=coords)
+        data = Data(coords=obj.wcs)
         data['data'] = obj.data
         data.get_component('data').units = str(obj.unit)
         data.meta.update(obj.meta)
@@ -42,12 +40,12 @@ class Specutils1DHandler:
             data = data_or_subset
             subset_state = None
 
-        if isinstance(data.coords, WCSCoordinates):
-            wcs = data.coords.wcs
+        if isinstance(data.coords, WCS):
+            wcs = data.coords
         elif type(data.coords) is Coordinates or data.coords is None:
             wcs = None
         else:
-            raise TypeError('data.coords should be an instance of Coordinates or WCSCoordinates')
+            raise TypeError('data.coords should be an instance of Coordinates or WCS')
 
         if isinstance(attribute, str):
             attribute = data.id[attribute]

--- a/glue_astronomy/translators/spectral_cube.py
+++ b/glue_astronomy/translators/spectral_cube.py
@@ -1,8 +1,10 @@
 import numpy as np
 
+from astropy.wcs.wcsapi import BaseLowLevelWCS
+
 from glue.config import data_translator
 from glue.core import Data, Subset
-from glue.core.coordinates import WCSCoordinates
+from astropy.wcs.wcsapi import BaseLowLevelWCS
 
 from astropy import units as u
 
@@ -13,8 +15,7 @@ from spectral_cube import SpectralCube, BooleanArrayMask
 class SpectralCubeHandler:
 
     def to_data(self, obj):
-        coords = WCSCoordinates(wcs=obj.wcs)
-        data = Data(coords=coords)
+        data = Data(coords=obj.wcs)
         data['flux'] = obj.filled_data[...]
         data.get_component('flux').units = str(obj.unit)
         data.meta.update(obj.meta)
@@ -43,10 +44,10 @@ class SpectralCubeHandler:
             data = data_or_subset
             subset_state = None
 
-        if isinstance(data.coords, WCSCoordinates):
-            wcs = data.coords.wcs
+        if isinstance(data.coords, BaseLowLevelWCS):
+            wcs = data.coords
         else:
-            raise TypeError('data.coords should be an instance of WCSCoordinates.')
+            raise TypeError('data.coords should be an instance of BaseLowLevelWCS.')
 
         if isinstance(attribute, str):
             attribute = data.id[attribute]

--- a/glue_astronomy/translators/spectral_cube.py
+++ b/glue_astronomy/translators/spectral_cube.py
@@ -4,7 +4,6 @@ from astropy.wcs.wcsapi import BaseLowLevelWCS
 
 from glue.config import data_translator
 from glue.core import Data, Subset
-from astropy.wcs.wcsapi import BaseLowLevelWCS
 
 from astropy import units as u
 

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -2,8 +2,8 @@ import numpy as np
 
 from glue.config import data_translator
 from glue.core import Data, Subset
-from glue.core.coordinates import WCSCoordinates
 
+from astropy.wcs import WCS
 from astropy import units as u
 from astropy.wcs import WCSSUB_SPECTRAL
 
@@ -44,15 +44,15 @@ class Specutils1DHandler:
             data = data_or_subset
             subset_state = None
 
-        if isinstance(data.coords, WCSCoordinates):
+        if isinstance(data.coords, WCS):
 
             # Find spectral axis
-            spec_axis = data.coords.wcs.naxis - 1 - data.coords.wcs.wcs.spec
+            spec_axis = data.coords.naxis - 1 - data.coords.wcs.spec
 
             # Find non-spectral axes
             axes = tuple(i for i in range(data.ndim) if i != spec_axis)
 
-            kwargs = {'wcs': data.coords.wcs.sub([WCSSUB_SPECTRAL])}
+            kwargs = {'wcs': data.coords.sub([WCSSUB_SPECTRAL])}
 
         elif isinstance(data.coords, SpectralCoordinates):
 
@@ -60,7 +60,7 @@ class Specutils1DHandler:
 
         else:
 
-            raise TypeError('data.coords should be an instance of WCSCoordinates '
+            raise TypeError('data.coords should be an instance of WCS '
                             'or SpectralCoordinates')
 
         if isinstance(attribute, str):

--- a/glue_astronomy/translators/tests/test_spectral_cube.py
+++ b/glue_astronomy/translators/tests/test_spectral_cube.py
@@ -10,7 +10,6 @@ from astropy.tests.helper import assert_quantity_allclose
 
 from glue.core import Data, DataCollection
 from glue.core.component import Component
-from glue.core.coordinates import WCSCoordinates
 
 
 @pytest.fixture
@@ -23,9 +22,7 @@ def spectral_cube_wcs():
 
 def test_to_spectral_cube(spectral_cube_wcs):
 
-    coords = WCSCoordinates(wcs=spectral_cube_wcs)
-
-    data = Data(label='spectral_cube', coords=coords)
+    data = Data(label='spectral_cube', coords=spectral_cube_wcs)
     values = np.random.random((4, 5, 3))
     data.add_component(Component(values, units='Jy'), 'x')
 
@@ -48,9 +45,7 @@ def test_to_spectral_cube(spectral_cube_wcs):
 
 def test_to_spectrum1d_unitless(spectral_cube_wcs):
 
-    coords = WCSCoordinates(wcs=spectral_cube_wcs)
-
-    data = Data(label='spectral_cube', coords=coords)
+    data = Data(label='spectral_cube', coords=spectral_cube_wcs)
     values = np.random.random((4, 5, 3))
     data.add_component(Component(values), 'x')
 
@@ -79,16 +74,14 @@ def test_to_spectrum1d_missing_wcs():
 
     with pytest.raises(TypeError) as exc:
         data.get_object(SpectralCube, attribute=data.id['x'])
-    assert exc.value.args[0] == ('data.coords should be an instance of WCSCoordinates.')
+    assert exc.value.args[0] == ('data.coords should be an instance of BaseLowLevelWCS.')
 
 
 def test_to_spectrum1d_invalid_wcs():
 
     wcs = WCS(naxis=3)
-    coords = WCSCoordinates(wcs=wcs)
 
-    data = Data(label='not-a-spectral-cube')
-    data.coords = coords
+    data = Data(label='not-a-spectral-cube', coords=wcs)
     values = np.random.random((4, 5, 3))
     data.add_component(Component(values, units='Jy'), 'x')
 
@@ -97,10 +90,8 @@ def test_to_spectrum1d_invalid_wcs():
     assert exc.value.args[0] == ('No celestial axes found in WCS')
 
     wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN', '']
-    coords = WCSCoordinates(wcs=wcs)
 
-    data = Data(label='not-a-spectral-cube')
-    data.coords = coords
+    data = Data(label='not-a-spectral-cube', coords=wcs)
     values = np.random.random((4, 5, 3))
     data.add_component(Component(values, units='Jy'), 'x')
 
@@ -111,9 +102,7 @@ def test_to_spectrum1d_invalid_wcs():
 
 def test_to_spectral_cube_default_attribute(spectral_cube_wcs):
 
-    coords = WCSCoordinates(wcs=spectral_cube_wcs)
-
-    data = Data(label='spectral_cube', coords=coords)
+    data = Data(label='spectral_cube', coords=spectral_cube_wcs)
     values = np.random.random((4, 5, 3))
 
     with pytest.raises(ValueError) as exc:

--- a/glue_astronomy/translators/tests/test_spectrum1d.py
+++ b/glue_astronomy/translators/tests/test_spectrum1d.py
@@ -10,7 +10,6 @@ from astropy.tests.helper import assert_quantity_allclose
 
 from glue.core import Data, DataCollection
 from glue.core.component import Component
-from glue.core.coordinates import WCSCoordinates
 
 from glue_astronomy.spectral_coordinates import SpectralCoordinates
 
@@ -22,9 +21,7 @@ def test_to_spectrum1d():
     wcs.wcs.ctype = ['VELO-LSR']
     wcs.wcs.set()
 
-    coords = WCSCoordinates(wcs=wcs)
-
-    data = Data(label='spectrum', coords=coords)
+    data = Data(label='spectrum', coords=wcs)
     data.add_component(Component(np.array([3.4, 2.3, -1.1, 0.3]), units='Jy'), 'x')
 
     spec = data.get_object(Spectrum1D, attribute=data.id['x'])
@@ -49,9 +46,7 @@ def test_to_spectrum1d_unitless():
     wcs.wcs.ctype = ['VELO-LSR']
     wcs.wcs.set()
 
-    coords = WCSCoordinates(wcs=wcs)
-
-    data = Data(label='spectrum', coords=coords)
+    data = Data(label='spectrum', coords=wcs)
     data.add_component(Component(np.array([3.4, 2.3, -1.1, 0.3])), 'x')
 
     spec = data.get_object(Spectrum1D, attribute=data.id['x'])
@@ -67,7 +62,7 @@ def test_to_spectrum1d_invalid():
 
     with pytest.raises(TypeError) as exc:
         data.get_object(Spectrum1D, attribute=data.id['x'])
-    assert exc.value.args[0] == ('data.coords should be an instance of WCSCoordinates '
+    assert exc.value.args[0] == ('data.coords should be an instance of WCS '
                                  'or SpectralCoordinates')
 
 
@@ -78,9 +73,7 @@ def test_to_spectrum1d_from_3d_cube():
     wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN', 'VELO-LSR']
     wcs.wcs.set()
 
-    coords = WCSCoordinates(wcs=wcs)
-
-    data = Data(label='spectral-cube', coords=coords)
+    data = Data(label='spectral-cube', coords=wcs)
     data.add_component(Component(np.ones((3, 4, 5)), units='Jy'), 'x')
 
     spec = data.get_object(Spectrum1D, attribute=data.id['x'], statistic='sum')
@@ -96,7 +89,7 @@ def test_to_spectrum1d_with_spectral_coordinates():
     data = Data(label='spectrum1d', coords=coords)
     data.add_component(Component(np.array([3, 4, 5]), units='Jy'), 'x')
 
-    assert_allclose(data.coords.pixel2world([0, 0.5, 1, 1.5, 2]),
+    assert_allclose(data.coords.pixel_to_world_values([0, 0.5, 1, 1.5, 2]),
                     [[1, 2.5, 4, 7, 10]])
 
     spec = data.get_object(Spectrum1D, attribute=data.id['x'])


### PR DESCRIPTION
This fixes the use of the glue.core.coordinates API to be APE-14 compliant as required by recent versions of glue-core.