### PR TITLE
Flip output masks to match specutils formalism

### DIFF
--- a/glue_astronomy/translators/ccddata.py
+++ b/glue_astronomy/translators/ccddata.py
@@ -72,7 +72,6 @@ class CCDDataHandler:
         else:
             mask = data.get_mask(subset_state=subset_state)
             values = values.copy()
-            values[~mask] = np.nan
             # Flip mask to match specutils formalism
             mask = ~mask
 

--- a/glue_astronomy/translators/ccddata.py
+++ b/glue_astronomy/translators/ccddata.py
@@ -76,4 +76,4 @@ class CCDDataHandler:
 
         values = values * u.Unit(component.units)
 
-        return CCDData(values, mask=mask, wcs=wcs)
+        return CCDData(values, mask=~mask, wcs=wcs)

--- a/glue_astronomy/translators/ccddata.py
+++ b/glue_astronomy/translators/ccddata.py
@@ -72,7 +72,7 @@ class CCDDataHandler:
         else:
             mask = data.get_mask(subset_state=subset_state)
             values = values.copy()
-            # Flip mask to match specutils formalism
+            # Flip mask to match astropy.ndddata formalism
             mask = ~mask
 
         values = values * u.Unit(component.units)

--- a/glue_astronomy/translators/ccddata.py
+++ b/glue_astronomy/translators/ccddata.py
@@ -73,7 +73,9 @@ class CCDDataHandler:
             mask = data.get_mask(subset_state=subset_state)
             values = values.copy()
             values[~mask] = np.nan
+            # Flip mask to match specutils formalism
+            mask = ~mask
 
         values = values * u.Unit(component.units)
 
-        return CCDData(values, mask=~mask, wcs=wcs)
+        return CCDData(values, mask=mask, wcs=wcs)

--- a/glue_astronomy/translators/spectral_cube.py
+++ b/glue_astronomy/translators/spectral_cube.py
@@ -72,6 +72,8 @@ class SpectralCubeHandler:
             values = values.copy()
             values[~mask] = np.nan
             mask = BooleanArrayMask(mask, wcs=wcs)
+            # Flip mask to match specutils formalism
+            mask = ~mask
 
         values = values * u.Unit(component.units)
 
@@ -85,4 +87,4 @@ class SpectralCubeHandler:
             values = values[slc[::-1]]
             wcs = wcs.sub(subkeep)
 
-        return SpectralCube(values, mask=~mask, wcs=wcs)
+        return SpectralCube(values, mask=mask, wcs=wcs)

--- a/glue_astronomy/translators/spectral_cube.py
+++ b/glue_astronomy/translators/spectral_cube.py
@@ -85,4 +85,4 @@ class SpectralCubeHandler:
             values = values[slc[::-1]]
             wcs = wcs.sub(subkeep)
 
-        return SpectralCube(values, mask=mask, wcs=wcs)
+        return SpectralCube(values, mask=~mask, wcs=wcs)

--- a/glue_astronomy/translators/spectral_cube.py
+++ b/glue_astronomy/translators/spectral_cube.py
@@ -70,7 +70,6 @@ class SpectralCubeHandler:
         else:
             mask = data.get_mask(subset_state=subset_state)
             values = values.copy()
-            values[~mask] = np.nan
             mask = BooleanArrayMask(mask, wcs=wcs)
             # Flip mask to match specutils formalism
             mask = ~mask

--- a/glue_astronomy/translators/spectral_cube.py
+++ b/glue_astronomy/translators/spectral_cube.py
@@ -71,8 +71,6 @@ class SpectralCubeHandler:
             mask = data.get_mask(subset_state=subset_state)
             values = values.copy()
             mask = BooleanArrayMask(mask, wcs=wcs)
-            # Flip mask to match specutils formalism
-            mask = ~mask
 
         values = values * u.Unit(component.units)
 

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -91,7 +91,6 @@ class Specutils1DHandler:
             else:
                 mask = data.get_mask(subset_state=subset_state)
                 values = values.copy()
-                values[~mask] = np.nan
                 # Flip mask to match specutils formalism
                 mask = ~mask
 

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -92,7 +92,9 @@ class Specutils1DHandler:
                 mask = data.get_mask(subset_state=subset_state)
                 values = values.copy()
                 values[~mask] = np.nan
+                # Flip mask to match specutils formalism
+                mask = ~mask
 
         values = values * u.Unit(component.units)
 
-        return Spectrum1D(values, mask=~mask, **kwargs)
+        return Spectrum1D(values, mask=mask, **kwargs)

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -95,4 +95,4 @@ class Specutils1DHandler:
 
         values = values * u.Unit(component.units)
 
-        return Spectrum1D(values, mask=mask, **kwargs)
+        return Spectrum1D(values, mask=~mask, **kwargs)

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -78,21 +78,23 @@ class Specutils1DHandler:
 
         component = data.get_component(attribute)
 
-        # Collapse values to profile
+        # Get mask if there is one defined, or if this is a subset
+        if subset_state is None:
+            mask = None
+        else:
+            mask = data.get_mask(subset_state=subset_state)
+            mask = ~mask
+
+        # Collapse values and mask to profile
         if data.ndim > 1:
             # Get units and attach to value
             values = data.compute_statistic(statistic, attribute, axis=axes,
                                             subset_state=subset_state)
-            mask = None
+            if mask is not None:
+                collapse_axes = tuple([x for x in range(1, data.ndim)])
+                mask = np.all(mask, collapse_axes)
         else:
             values = data.get_data(attribute)
-            if subset_state is None:
-                mask = None
-            else:
-                mask = data.get_mask(subset_state=subset_state)
-                values = values.copy()
-                # Flip mask to match specutils formalism
-                mask = ~mask
 
         values = values * u.Unit(component.units)
 

--- a/glue_astronomy/translators/tests/test_ccddata.py
+++ b/glue_astronomy/translators/tests/test_ccddata.py
@@ -38,9 +38,9 @@ def test_to_ccddata(with_wcs):
                                           attribute=data.id['x'])
 
     assert image_subset.wcs is (WCS_CELESTIAL if with_wcs else None)
-    assert_allclose(image_subset.data, [[3.4, 2.3], [np.nan, np.nan]])
+    assert_allclose(image_subset.data, [[3.4, 2.3], [-1.1, 0.3]])
     assert image_subset.unit is u.Jy
-    assert_equal(image_subset.mask, [[1, 1], [0, 0]])
+    assert_equal(image_subset.mask, [[0, 0], [1, 1]])
 
 
 def test_to_ccddata_unitless():

--- a/glue_astronomy/translators/tests/test_spectrum1d.py
+++ b/glue_astronomy/translators/tests/test_spectrum1d.py
@@ -35,8 +35,8 @@ def test_to_spectrum1d():
                                          attribute=data.id['x'])
 
     assert_quantity_allclose(spec_subset.spectral_axis, [1, 2, 3, 4] * u.m / u.s)
-    assert_quantity_allclose(spec_subset.flux, [3.4, 2.3, np.nan, np.nan] * u.Jy)
-    assert_equal(spec_subset.mask, [1, 1, 0, 0])
+    assert_quantity_allclose(spec_subset.flux, [3.4, 2.3, -1.1, 0.3] * u.Jy)
+    assert_equal(spec_subset.mask, [0, 0, 1, 1])
 
 
 def test_to_spectrum1d_unitless():


### PR DESCRIPTION
Glue defines a "mask" as a boolean array where `True` denotes valid data, whereas specutils expects the opposite (`True` in a mask means the data there is masked out/invalid). This PR flips the mask array in the output of the relevant data translators to match what specutils expects, fixing errors that I was getting in multiple plugins of [Jdaviz](https://github.com/spacetelescope/jdaviz/) due to the masks.