### PR TITLE
Use uncertainties and mask from `Spectrum1D`

### DIFF
--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -19,7 +19,10 @@ class Specutils1DHandler:
         coords = SpectralCoordinates(obj.spectral_axis)
         data = Data(coords=coords)
         data['flux'] = obj.flux
+        data['uncertainty'] = obj.uncertainty.array if obj.uncertainty is not None else np.ones(obj.flux.shape)
+        data['mask'] = obj.mask if hasattr(obj, 'mask') and obj.mask is not None else np.zeros(obj.flux.shape).astype(bool)
         data.get_component('flux').units = str(obj.unit)
+        data.get_component('uncertainty').units = str(obj.unit)
         data.meta.update(obj.meta)
         return data
 
@@ -70,6 +73,8 @@ class Specutils1DHandler:
         elif attribute is None:
             if len(data.main_components) == 1:
                 attribute = data.main_components[0]
+            elif 'flux' in data.components:
+                attribute = data.find_component_id('flux')
             else:
                 raise ValueError("Data object has more than one attribute, so "
                                  "you will need to specify which one to use as "

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -82,8 +82,11 @@ class Specutils1DHandler:
         elif attribute is None:
             if len(data.main_components) == 1:
                 attribute = data.main_components[0]
-            elif 'flux' in [x.label for x in data.components]:
-                attribute = data.find_component_id('flux')
+            # If no specific attribute is defined, attempt to retrieve
+            #  both the flux and uncertainties
+            elif any([x.label in ('flux', 'uncertainty') for x in data.components]):
+                attribute = [data.find_component_id('flux'),
+                             data.find_component_id('uncertainty')]
             else:
                 raise ValueError("Data object has more than one attribute, so "
                                  "you will need to specify which one to use as "

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -19,14 +19,20 @@ class Specutils1DHandler:
         coords = SpectralCoordinates(obj.spectral_axis)
         data = Data(coords=coords)
         data['flux'] = obj.flux
-        data['uncertainty'] = obj.uncertainty.array \
-            if obj.uncertainty is not None else np.ones(obj.flux.shape)
-        data['mask'] = obj.mask \
-            if hasattr(obj, 'mask') and obj.mask is not None \
-            else np.zeros(obj.flux.shape).astype(bool)
         data.get_component('flux').units = str(obj.unit)
-        data.get_component('uncertainty').units = str(obj.unit)
+
+        # Include uncertainties if they exist
+        if obj.uncertainty is not None:
+            data['uncertainty'] = obj.uncertainty.quantity
+            data.get_component('uncertainty').units = str(obj.unit)
+            data.meta.update({'uncertainty_type': obj.uncertainty.uncertainty_type})
+
+        # Include mask if it exists
+        if obj.mask is not None:
+            data['mask'] = obj.mask
+
         data.meta.update(obj.meta)
+        
         return data
 
     def to_object(self, data_or_subset, attribute=None, statistic='mean'):

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -76,7 +76,7 @@ class Specutils1DHandler:
         elif attribute is None:
             if len(data.main_components) == 1:
                 attribute = data.main_components[0]
-            elif 'flux' in data.components:
+            elif 'flux' in [x.label for x in data.components]:
                 attribute = data.find_component_id('flux')
             else:
                 raise ValueError("Data object has more than one attribute, so "

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -19,8 +19,11 @@ class Specutils1DHandler:
         coords = SpectralCoordinates(obj.spectral_axis)
         data = Data(coords=coords)
         data['flux'] = obj.flux
-        data['uncertainty'] = obj.uncertainty.array if obj.uncertainty is not None else np.ones(obj.flux.shape)
-        data['mask'] = obj.mask if hasattr(obj, 'mask') and obj.mask is not None else np.zeros(obj.flux.shape).astype(bool)
+        data['uncertainty'] = obj.uncertainty.array \
+            if obj.uncertainty is not None else np.ones(obj.flux.shape)
+        data['mask'] = obj.mask \
+            if hasattr(obj, 'mask') and obj.mask is not None \
+            else np.zeros(obj.flux.shape).astype(bool)
         data.get_component('flux').units = str(obj.unit)
         data.get_component('uncertainty').units = str(obj.unit)
         data.meta.update(obj.meta)

--- a/glue_astronomy/translators/tests/test_spectrum1d.py
+++ b/glue_astronomy/translators/tests/test_spectrum1d.py
@@ -143,7 +143,7 @@ def test_from_spectrum1d(mode):
     data = data_collection['spectrum']
 
     assert isinstance(data, Data)
-    assert len(data.main_components) == 1
+    assert len(data.main_components) == 3
     assert data.main_components[0].label == 'flux'
     assert_allclose(data['flux'], [2, 3, 4, 5])
     component = data.get_component('flux')

--- a/glue_astronomy/translators/tests/test_spectrum1d.py
+++ b/glue_astronomy/translators/tests/test_spectrum1d.py
@@ -137,7 +137,8 @@ def test_from_spectrum1d(mode):
 
     spec = Spectrum1D([2, 3, 4, 5] * u.Jy, 
                       uncertainty=StdDevUncertainty(
-                          [0.1, 0.1, 0.1, 0.1] * u.Jy), 
+                          [0.1, 0.1, 0.1, 0.1] * u.Jy),
+                      mask=[False, False, False, False], 
                       **kwargs)
 
     data_collection = DataCollection()
@@ -147,7 +148,7 @@ def test_from_spectrum1d(mode):
     data = data_collection['spectrum']
 
     assert isinstance(data, Data)
-    assert len(data.main_components) == 2
+    assert len(data.main_components) == 3
     assert data.main_components[0].label == 'flux'
     assert_allclose(data['flux'], [2, 3, 4, 5])
     component = data.get_component('flux')
@@ -166,7 +167,7 @@ def test_from_spectrum1d(mode):
     assert_quantity_allclose(spec_new.flux, [2, 3, 4, 5] * u.Jy)
     assert spec_new.uncertainty is None
 
-    # Check complete rouch-tripping, including uncertainties
+    # Check complete round-tripping, including uncertainties
     spec_new = data.get_object()
     assert isinstance(spec_new, Spectrum1D)
     assert_quantity_allclose(spec_new.spectral_axis, [1, 2, 3, 4] * u.Hz)

--- a/glue_astronomy/translators/tests/test_spectrum1d.py
+++ b/glue_astronomy/translators/tests/test_spectrum1d.py
@@ -147,7 +147,7 @@ def test_from_spectrum1d(mode):
     data = data_collection['spectrum']
 
     assert isinstance(data, Data)
-    assert len(data.main_components) == 3
+    assert len(data.main_components) == 2
     assert data.main_components[0].label == 'flux'
     assert_allclose(data['flux'], [2, 3, 4, 5])
     component = data.get_component('flux')

--- a/glue_astronomy/translators/tests/test_spectrum1d.py
+++ b/glue_astronomy/translators/tests/test_spectrum1d.py
@@ -135,10 +135,10 @@ def test_from_spectrum1d(mode):
 
         kwargs = {'spectral_axis': [1, 2, 3, 4] * u.Hz}
 
-    spec = Spectrum1D([2, 3, 4, 5] * u.Jy, 
+    spec = Spectrum1D([2, 3, 4, 5] * u.Jy,
                       uncertainty=StdDevUncertainty(
                           [0.1, 0.1, 0.1, 0.1] * u.Jy),
-                      mask=[False, False, False, False], 
+                      mask=[False, False, False, False],
                       **kwargs)
 
     data_collection = DataCollection()


### PR DESCRIPTION
This updates the `Spectrum1D` translator to also include the uncertainties and mask on the spectrum instance as glue components.