### PR TITLE
added roundtrip test for Spectrum1D w/ masks

### DIFF
--- a/glue_astronomy/translators/tests/test_spectrum1d.py
+++ b/glue_astronomy/translators/tests/test_spectrum1d.py
@@ -174,3 +174,21 @@ def test_from_spectrum1d(mode):
     assert_quantity_allclose(spec_new.flux, [2, 3, 4, 5] * u.Jy)
     assert spec_new.uncertainty is not None
     assert_quantity_allclose(spec_new.uncertainty.quantity, [0.1, 0.1, 0.1, 0.1] * u.Jy)
+
+@pytest.mark.parametrize('maskdtype', (bool, int))
+def test_spectrum1d_mask_roundtrip(maskdtype):
+    maskvals = np.array([1, 0, 2, 0], dtype=maskdtype)
+    # for a bool dtype this becomes [True, False, True, False]
+
+    spec = Spectrum1D(spectral_axis=[1, 2, 3, 4]*u.micron,
+                      flux=[11, 12.5, 13, 14]*u.Jy,
+                      mask=maskvals)
+
+    data_collection = DataCollection()
+    data_collection['spectrum'] = spec
+
+    rtspec = data_collection['spectrum'].get_object(spec.__class__)
+
+    assert np.all(rtspec.mask == maskvals)
+    assert u.allclose(rtspec.spectral_axis, spec.spectral_axis)
+    assert u.allclose(rtspec.flux, spec.flux)


### PR DESCRIPTION
This PR is currently just a (non-functional) test for round-tripping behavior in Spectrum1D.  Meant as a starting point for test-driven development regarding an issue I'm about to create