### PR TITLE
Use different coords for 3d and 1d Spectrum1D objects

### DIFF
--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -21,8 +21,11 @@ UNCERT_REF = {'std': StdDevUncertainty,
 class Specutils1DHandler:
 
     def to_data(self, obj):
-        coords = SpectralCoordinates(obj.spectral_axis)
-        data = Data(coords=coords)
+        if len(obj.shape) == 1:
+            coords = SpectralCoordinates(obj.spectral_axis)
+            data = Data(coords=coords)
+        else:
+            data = Data(coords=obj.wcs)
         data['flux'] = obj.flux
         data.get_component('flux').units = str(obj.unit)
 


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes #28 
Uses different coords depending on if the object is a Spectrum1D of shape 1 or other (in the jdaviz case, 3). The motivation for this change is to implement the latest changes to Spectrum1D that replace the SpectralCube functionality with NDCube.
