### PR TITLE
libgfortran3 -> libgfortran5

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
     libraries:
       apt:
         - libxkbcommon-x11-0
-        - libgfortran3
+        - libgfortran5
       brew:
         - enchant
 


### PR DESCRIPTION
This is an attempt to fix the liunux CI that's been broken for a while.

I think this might be trivial.  libgfortran3 is pretty old and hence is gone from some more recent linux distros.  I'm not certain what ubuntu version the CI is currently running on, but seems like a reasonable wild guess...