### PR TITLE
BUG: Do not crash when masking fails

### DIFF
--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from glue.config import data_translator
 from glue.core import Data, Subset
+from glue.core.exceptions import IncompatibleAttribute
 
 from astropy.wcs import WCS
 from astropy import units as u
@@ -108,8 +109,12 @@ class Specutils1DHandler:
                 if subset_state is None:
                     mask = None
                 else:
-                    mask = data.get_mask(subset_state=subset_state)
-                    mask = ~mask
+                    try:
+                        mask = data.get_mask(subset_state=subset_state)
+                        mask = ~mask
+                    except IncompatibleAttribute:
+                        # Like when trying to apply image mask to spectrum
+                        mask = None
 
                 # Collapse values and mask to profile
                 if data.ndim > 1:


### PR DESCRIPTION
## Description

In Cubeviz workflow, when user creates subset on the collapsed image (2D) and then select that subset for model fitting plugin, it tries to grab a 2D mask from a 1D spectrum, which crashes spectacularly. User sees a traceback albeit successful fitting. (Success here means something shows; I have no idea if the fit is actually correct or not, but that is out of scope here.)

This patch prevent `get_mask` from crashing when this use case is encountered.

Part of https://jira.stsci.edu/browse/JDAT-1671

p.s. Not sure how much this conflicts with #36 