### PR TITLE
Change Spectrum1DHandler default stat back to mean

### DIFF
--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -59,7 +59,7 @@ class Specutils1DHandler:
 
         return data
 
-    def to_object(self, data_or_subset, attribute=None, statistic=None):
+    def to_object(self, data_or_subset, attribute=None, statistic='mean'):
         """
         Convert a glue Data object to a Spectrum1D object.
 


### PR DESCRIPTION
## Description

This is my attempt to fix spacetelescope/jdaviz#821 . With this patch, the code snippet posted in spacetelescope/jdaviz#821 went from traceback to this:

```python
>>> spec = data.get_object(cls=Spectrum1D) 
<Spectrum1D(flux=<Quantity [1., 1., 1.]>, spectral_axis=<SpectralAxis
   (observer to target:
      radial_velocity=0.0 km / s
      redshift=0.0)
  [1., 2., 3.] Hz>)>
```

I don't grok why the default was changed in #36 , so @rosteen or @astrofrog can comment.