### PR TITLE
Support Spectrum1D objects with 2D data and 1D WCS

### DIFF
--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -44,35 +44,35 @@ class PaddedSpectrumWCS(BaseWCSWrapper, HighLevelWCSMixin):
 
     @property
     def world_axis_physical_types(self):
-        return [None, self.spectral_wcs.world_axis_physical_types[0]]
+        return [self.spectral_wcs.world_axis_physical_types[0], None]
 
     @property
     def world_axis_units(self):
-        return (None, self.spectral_wcs.world_axis_units[0])
+        return (self.spectral_wcs.world_axis_units[0], None)
 
     def pixel_to_world_values(self, *pixel_arrays):
-        world_arrays = [pixel_arrays[0],
-                        self.spectral_wcs.pixel_to_world_values(pixel_arrays[1])]
+        world_arrays = [self.spectral_wcs.pixel_to_world_values(pixel_arrays[1]),
+                        pixel_arrays[0]]
         return tuple(world_arrays)
 
     def world_to_pixel_values(self, *world_arrays):
-        pixel_arrays = [world_arrays[0],
-                        self.spectral_wcs.world_to_pixel_values(world_arrays[0])]
+        pixel_arrays = [self.spectral_wcs.world_to_pixel_values(world_arrays[0]),
+                        world_arrays[0]]
         return tuple(pixel_arrays)
 
     @property
     def world_axis_object_components(self):
         return [
-            ('spatial', 'value', 'value'),
-            self.spectral_wcs.world_axis_object_components[0]
+            self.spectral_wcs.world_axis_object_components[0],
+            ('spatial', 'value', 'value')
         ]
 
     @property
     def world_axis_object_classes(self):
         spectral_key = self.spectral_wcs.world_axis_object_components[0][0]
         return {
-            'spatial': (u.Quantity, (), {'unit': u.pixel}),
-            spectral_key: self.spectral_wcs.world_axis_object_classes[spectral_key]
+            spectral_key: self.spectral_wcs.world_axis_object_classes[spectral_key],
+            'spatial': (u.Quantity, (), {'unit': u.pixel})
         }
 
     @property
@@ -85,11 +85,11 @@ class PaddedSpectrumWCS(BaseWCSWrapper, HighLevelWCSMixin):
 
     @property
     def pixel_axis_names(self):
-        return tuple(['spatial', self.spectral_wcs.pixel_axis_names[0]])
+        return tuple([self.spectral_wcs.pixel_axis_names[0], 'spatial'])
 
     @property
     def world_axis_names(self):
-        return tuple(['spatial', self.spectral_wcs.world_axis_names[0]])
+        return tuple([self.spectral_wcs.world_axis_names[0], 'spatial'])
 
     @property
     def axis_correlation_matrix(self):

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -7,6 +7,9 @@ from astropy.wcs import WCS
 from astropy import units as u
 from astropy.wcs import WCSSUB_SPECTRAL
 from astropy.nddata import StdDevUncertainty, InverseVariance, VarianceUncertainty
+from astropy.wcs.wcsapi.wrappers.base import BaseWCSWrapper
+from astropy.wcs.wcsapi import HighLevelWCSMixin
+
 from gwcs import WCS as GWCS
 
 from glue_astronomy.spectral_coordinates import SpectralCoordinates
@@ -16,6 +19,85 @@ from specutils import Spectrum1D
 UNCERT_REF = {'std': StdDevUncertainty,
               'var': VarianceUncertainty,
               'ivar': InverseVariance}
+
+
+class PaddedSpectrumWCS(BaseWCSWrapper, HighLevelWCSMixin):
+
+    # Spectrum1D can use a 1D spectral WCS even for n-dimensional
+    # datasets while glue always needs the dimensionality to match,
+    # so this class pads the WCS so that it is n-dimensional.
+
+    # NOTE: for now this only handles padding the WCS into 2D WCS. Rather than
+    # generalize this we can just remove this class and use CompoundLowLevelWCS
+    # from NDCube once it is in a released version.
+
+    def __init__(self, wcs):
+        self.spectral_wcs = wcs
+
+    @property
+    def pixel_n_dim(self):
+        return 2
+
+    @property
+    def world_n_dim(self):
+        return 2
+
+    @property
+    def world_axis_physical_types(self):
+        return [None, self.spectral_wcs.world_axis_physical_types[0]]
+
+    @property
+    def world_axis_units(self):
+        return (None, self.spectral_wcs.world_axis_units[0])
+
+    def pixel_to_world_values(self, *pixel_arrays):
+        world_arrays = [pixel_arrays[0],
+                        self.spectral_wcs.pixel_to_world_values(pixel_arrays[1])]
+        return tuple(world_arrays)
+
+    def world_to_pixel_values(self, *world_arrays):
+        pixel_arrays = [world_arrays[0],
+                        self.spectral_wcs.world_to_pixel_values(world_arrays[0])]
+        return tuple(pixel_arrays)
+
+    @property
+    def world_axis_object_components(self):
+        return [
+            ('spatial', 'value', 'value'),
+            self.spectral_wcs.world_axis_object_components[0]
+        ]
+
+    @property
+    def world_axis_object_classes(self):
+        spectral_key = self.spectral_wcs.world_axis_object_components[0][0]
+        return {
+            'spatial': (u.Quantity, (), {'unit': u.pixel}),
+            spectral_key: self.spectral_wcs.world_axis_object_classes[spectral_key]
+        }
+
+    @property
+    def pixel_shape(self):
+        return None
+
+    @property
+    def pixel_bounds(self):
+        return None
+
+    @property
+    def pixel_axis_names(self):
+        return tuple(['spatial', self.spectral_wcs.pixel_axis_names[0]])
+
+    @property
+    def world_axis_names(self):
+        return tuple(['spatial', self.spectral_wcs.world_axis_names[0]])
+
+    @property
+    def axis_correlation_matrix(self):
+        return np.identity(2).astype('bool')
+
+    @property
+    def serialized_classes(self):
+        return False
 
 
 @data_translator(Spectrum1D)
@@ -31,9 +113,8 @@ class Specutils1DHandler:
             data['flux'] = np.swapaxes(obj.flux, -1, 0)
             data.get_component('flux').units = str(obj.unit)
         else:
-            # Don't use the dummy GWCS created by Spectrum1D initialized with spectral_axis
-            if isinstance(obj.wcs, GWCS):
-                data = Data(coords=SpectralCoordinates(obj.spectral_axis))
+            if obj.flux.ndim == 2 and obj.wcs.world_n_dim == 1:
+                data = Data(coords=PaddedSpectrumWCS(obj.wcs))
             else:
                 data = Data(coords=obj.wcs)
             data['flux'] = obj.flux
@@ -92,6 +173,10 @@ class Specutils1DHandler:
                 kwargs = {'wcs': data.coords.sub([WCSSUB_SPECTRAL])}
             else:
                 kwargs = {'wcs': data.coords}
+
+        elif isinstance(data.coords, PaddedSpectrumWCS):
+
+            kwargs = {'wcs': data.coords.spectral_wcs}
 
         elif isinstance(data.coords, SpectralCoordinates):
 

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -10,8 +10,6 @@ from astropy.nddata import StdDevUncertainty, InverseVariance, VarianceUncertain
 from astropy.wcs.wcsapi.wrappers.base import BaseWCSWrapper
 from astropy.wcs.wcsapi import HighLevelWCSMixin, BaseHighLevelWCS
 
-from gwcs import WCS as GWCS
-
 from glue_astronomy.spectral_coordinates import SpectralCoordinates
 
 from specutils import Spectrum1D

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -159,6 +159,9 @@ class Specutils1DHandler:
             data = data_or_subset
             subset_state = None
 
+        if data.ndim < 2 and statistic is not None:
+            statistic = None
+
         if statistic is None and isinstance(data.coords, BaseHighLevelWCS):
 
             if isinstance(data.coords, PaddedSpectrumWCS):

--- a/glue_astronomy/translators/tests/test_spectrum1d.py
+++ b/glue_astronomy/translators/tests/test_spectrum1d.py
@@ -201,7 +201,6 @@ def test_from_spectrum1d(mode):
         assert_quantity_allclose(spec_new.uncertainty.quantity, [0.1, 0.1, 0.1, 0.1] * u.Jy**2)
 
 
-
 def test_spectrum1d_2d_data():
 
     # This test makes sure that 2D spectra represented as Spectrum1D round-trip

--- a/glue_astronomy/translators/tests/test_spectrum1d.py
+++ b/glue_astronomy/translators/tests/test_spectrum1d.py
@@ -238,7 +238,7 @@ def test_spectrum1d_2d_data():
     assert len(data.pixel_component_ids) == 2
     assert len(data.world_component_ids) == 2
 
-    _, s = data.coords.pixel_to_world(1, 2)
+    s, _ = data.coords.pixel_to_world(1, 2)
 
     assert isinstance(s, SpectralCoord)
 

--- a/glue_astronomy/translators/tests/test_spectrum1d.py
+++ b/glue_astronomy/translators/tests/test_spectrum1d.py
@@ -242,7 +242,7 @@ def test_spectrum1d_2d_data():
     assert isinstance(s, SpectralCoord)
 
     # Check round-tripping
-    spec_new = data.get_object()
+    spec_new = data.get_object(statistic=None)
     assert isinstance(spec_new, Spectrum1D)
 
     # The WCS object should be the same

--- a/glue_astronomy/translators/tests/test_spectrum1d.py
+++ b/glue_astronomy/translators/tests/test_spectrum1d.py
@@ -175,7 +175,7 @@ def test_from_spectrum1d(mode):
     assert component.units == 'Jy2'
 
     # Check round-tripping via single attribute reference
-    spec_new = data.get_object(attribute='flux')
+    spec_new = data.get_object(attribute='flux', statistic=None)
     assert isinstance(spec_new, Spectrum1D)
     assert_quantity_allclose(spec_new.spectral_axis, [1, 2, 3, 4] * u.Hz)
     if mode == 'wcs3d':
@@ -185,7 +185,7 @@ def test_from_spectrum1d(mode):
     assert spec_new.uncertainty is None
 
     # Check complete round-tripping, including uncertainties
-    spec_new = data.get_object()
+    spec_new = data.get_object(statistic=None)
     assert isinstance(spec_new, Spectrum1D)
     assert_quantity_allclose(spec_new.spectral_axis, [1, 2, 3, 4] * u.Hz)
     if mode == 'wcs3d':


### PR DESCRIPTION
This adds a way to translate Spectrum1D objects with 1D spectral WCS and 2D datasets to glue objects and back, and is needed for https://github.com/spacetelescope/jdaviz/pull/733. In future we should just support ND datasets with 1D WCS but the code for that will be a bit more complex and it would be easier to just wait for a release of NDCube so that we can use the compound WCS class from there. For now this PR makes it possible to support 2D spectra.

This also removes the use of SpectralCoordinate in ``to_data`` as glue and Spectrum1D now both support GWCS.