### PR TITLE
add more spectral-cube class translators

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@
 
 - Fixed unit parsing for ``Specutils1DHandler.to_data`` so it no longer
   drops the flux unit in some cases. [#78]
+- Added support for a wider range of spectral-cube objects [#54]
 
 0.5.0 (2022-08-18)
 ------------------

--- a/glue_astronomy/translators/spectral_cube.py
+++ b/glue_astronomy/translators/spectral_cube.py
@@ -6,6 +6,7 @@ from glue.core import Data, Subset
 from astropy import units as u
 from astropy.wcs import WCSSUB_STOKES, WCS
 
+from spectral_cube import BooleanArrayMask
 from spectral_cube.spectral_cube import BaseSpectralCube, SpectralCube, VaryingResolutionSpectralCube
 from spectral_cube.dask_spectral_cube import DaskSpectralCube, DaskVaryingResolutionSpectralCube
 

--- a/glue_astronomy/translators/spectral_cube.py
+++ b/glue_astronomy/translators/spectral_cube.py
@@ -7,7 +7,8 @@ from astropy import units as u
 from astropy.wcs import WCSSUB_STOKES, WCS
 
 from spectral_cube import BooleanArrayMask
-from spectral_cube.spectral_cube import BaseSpectralCube, SpectralCube, VaryingResolutionSpectralCube
+from spectral_cube.spectral_cube import (BaseSpectralCube, SpectralCube, 
+                                         VaryingResolutionSpectralCube)
 from spectral_cube.dask_spectral_cube import DaskSpectralCube, DaskVaryingResolutionSpectralCube
 
 
@@ -86,6 +87,7 @@ class SpectralCubeHandler:
 
         return cls(values, mask=mask, wcs=wcs, meta=data.meta)
 
+
 data_translator(SpectralCube)(SpectralCubeHandler)
 data_translator(DaskSpectralCube)(SpectralCubeHandler)
 
@@ -101,5 +103,6 @@ class VaryingResolutionSpectralCubeHandler(SpectralCubeHandler):
     def to_object(self, data_or_subset, attribute=None, cls=VaryingResolutionSpectralCube):
         return super().to_object(data_or_subset, attribute=attribute, cls=cls,
                                  beams=data_or_subset.meta['beams'])
+
 
 data_translator(DaskVaryingResolutionSpectralCube)(VaryingResolutionSpectralCubeHandler)

--- a/glue_astronomy/translators/spectral_cube.py
+++ b/glue_astronomy/translators/spectral_cube.py
@@ -6,10 +6,11 @@ from glue.core import Data, Subset
 from astropy import units as u
 from astropy.wcs import WCSSUB_STOKES, WCS
 
-from spectral_cube import SpectralCube, BooleanArrayMask
+from spectral_cube.spectral_cube import BaseSpectralCube, SpectralCube, VaryingResolutionSpectralCube
+from spectral_cube.dask_spectral_cube import DaskSpectralCube, DaskVaryingResolutionSpectralCube
 
 
-@data_translator(SpectralCube)
+@data_translator(BaseSpectralCube)
 class SpectralCubeHandler:
 
     def to_data(self, obj):
@@ -19,7 +20,7 @@ class SpectralCubeHandler:
         data.meta.update(obj.meta)
         return data
 
-    def to_object(self, data_or_subset, attribute=None):
+    def to_object(self, data_or_subset, attribute=None, cls=SpectralCube):
         """
         Convert a glue Data object to a SpectralCube object.
 
@@ -82,4 +83,22 @@ class SpectralCubeHandler:
             values = values[slc[::-1]]
             wcs = wcs.sub(subkeep)
 
-        return SpectralCube(values, mask=mask, wcs=wcs, meta=data.meta)
+        return cls(values, mask=mask, wcs=wcs, meta=data.meta)
+
+datatranslator(SpectralCube, SpectralCubeHandler)
+datatranslator(DaskSpectralCube, SpectralCubeHandler)
+
+
+@data_translator(VaryingResolutionSpectralCube)
+class VaryingResolutionSpectralCubeHandler(SpectralCubeHandler):
+
+    def to_data(self, obj):
+        data = super().to_data(obj)
+        data.meta['beams'] = obj.beams
+        return data
+
+    def to_object(self, data_or_subset, attribute=None, cls=VaryingResolutionSpectralCube):
+        return super().to_object(data_or_subset, attribute=attribute, cls=cls,
+                                 beams=data_or_subset.meta['beams'])
+
+datatranslator(DaskVaryingResolutionSpectralCube, VaryingResolutionSpectralCubeHandler)

--- a/glue_astronomy/translators/spectral_cube.py
+++ b/glue_astronomy/translators/spectral_cube.py
@@ -7,7 +7,7 @@ from astropy import units as u
 from astropy.wcs import WCSSUB_STOKES, WCS
 
 from spectral_cube import BooleanArrayMask
-from spectral_cube.spectral_cube import (BaseSpectralCube, SpectralCube, 
+from spectral_cube.spectral_cube import (BaseSpectralCube, SpectralCube,
                                          VaryingResolutionSpectralCube)
 from spectral_cube.dask_spectral_cube import DaskSpectralCube, DaskVaryingResolutionSpectralCube
 

--- a/glue_astronomy/translators/spectral_cube.py
+++ b/glue_astronomy/translators/spectral_cube.py
@@ -85,8 +85,8 @@ class SpectralCubeHandler:
 
         return cls(values, mask=mask, wcs=wcs, meta=data.meta)
 
-datatranslator(SpectralCube, SpectralCubeHandler)
-datatranslator(DaskSpectralCube, SpectralCubeHandler)
+data_translator(SpectralCube, SpectralCubeHandler)
+data_translator(DaskSpectralCube, SpectralCubeHandler)
 
 
 @data_translator(VaryingResolutionSpectralCube)
@@ -101,4 +101,4 @@ class VaryingResolutionSpectralCubeHandler(SpectralCubeHandler):
         return super().to_object(data_or_subset, attribute=attribute, cls=cls,
                                  beams=data_or_subset.meta['beams'])
 
-datatranslator(DaskVaryingResolutionSpectralCube, VaryingResolutionSpectralCubeHandler)
+data_translator(DaskVaryingResolutionSpectralCube, VaryingResolutionSpectralCubeHandler)

--- a/glue_astronomy/translators/spectral_cube.py
+++ b/glue_astronomy/translators/spectral_cube.py
@@ -85,8 +85,8 @@ class SpectralCubeHandler:
 
         return cls(values, mask=mask, wcs=wcs, meta=data.meta)
 
-data_translator(SpectralCube, SpectralCubeHandler)
-data_translator(DaskSpectralCube, SpectralCubeHandler)
+data_translator(SpectralCube)(SpectralCubeHandler)
+data_translator(DaskSpectralCube)(SpectralCubeHandler)
 
 
 @data_translator(VaryingResolutionSpectralCube)
@@ -101,4 +101,4 @@ class VaryingResolutionSpectralCubeHandler(SpectralCubeHandler):
         return super().to_object(data_or_subset, attribute=attribute, cls=cls,
                                  beams=data_or_subset.meta['beams'])
 
-data_translator(DaskVaryingResolutionSpectralCube, VaryingResolutionSpectralCubeHandler)
+data_translator(DaskVaryingResolutionSpectralCube)(VaryingResolutionSpectralCubeHandler)


### PR DESCRIPTION
The `SpectralCube` handlers didn't work for any but the basic single-beam SpectralCube objects.  This adds support for the other types.

I haven't tested this extensively yet, but I think the ideas are sound - as long as the metadata is appropriately preserved.

Problem: `beams` needs to be subsetted along with the data.  How can we handle that?
