### PR TITLE
Fix attribute handling for Jdaviz/Cubeviz parser

### DIFF
--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -228,10 +228,11 @@ class Specutils1DHandler:
             if len(data.main_components) == 1:
                 attribute = data.main_components[0]
             # If no specific attribute is defined, attempt to retrieve
-            #  both the flux and uncertainties
+            # the flux and uncertainty, if available
             elif any([x.label in ('flux', 'uncertainty') for x in data.components]):
-                attribute = [data.find_component_id('flux'),
-                             data.find_component_id('uncertainty')]
+                attribute = [data.find_component_id(x)
+                             for x in ('flux', 'uncertainty')
+                             if data.find_component_id(x) is not None]
             else:
                 raise ValueError("Data object has more than one attribute, so "
                                  "you will need to specify which one to use as "


### PR DESCRIPTION
## Description

This PR fixes regression in Cubeviz parser behavior introduced in spacetelescope/jdaviz#547 , particularly getting rid of the assumption that "uncertainty" is always available when "flux" is available, which is not always true.

~Also refactor the internal logic a little.~

Fixes spacetelescope/jdaviz#967