### PR TITLE
Fix bug in translating 3D Spectrum1D with only spectral axis defined

### DIFF
--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -126,7 +126,10 @@ class Specutils1DHandler:
         # Swap the spectral axis to first here. to_object doesn't need this because
         # Spectrum1D does it automatically on initialization.
         if len(obj.flux.shape) == 3:
-            data = Data(coords=obj.wcs.swapaxes(-1, 0))
+            # It's possible to have a 3D Spectrum1D with only a spectral axis defined
+            # rather than a full WCS, in which case we don't need to swap the WCS
+            if obj.wcs.world_n_dim == 3:
+                data = Data(coords=obj.wcs.swapaxes(-1, 0))
             data['flux'] = np.swapaxes(obj.flux, -1, 0)
             data.get_component('flux').units = str(obj.unit)
         else:

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -125,8 +125,12 @@ class Specutils1DHandler:
         if data.ndim < 2 and statistic is not None:
             statistic = None
 
+        manual_swap = None
+
         if statistic is None and isinstance(data.coords, PaddedSpectrumWCS):
             kwargs = {'wcs': data.coords.spectral_wcs}
+            if data.ndim > 1:
+                manual_swap = True
         elif statistic is None and isinstance(data.coords, BaseHighLevelWCS):
             kwargs = {'wcs': data.coords}
 
@@ -202,6 +206,9 @@ class Specutils1DHandler:
                         mask = np.all(mask, collapse_axes)
                 else:
                     values = data.get_data(attribute)
+                    if manual_swap:
+                        # In this case we need to move the spectral axis back to last
+                        values = np.swapaxes(values, -1, 0)
 
                 attribute_label = attribute.label
 

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -10,8 +10,7 @@ from astropy.wcs import WCS
 from astropy import units as u
 from astropy.wcs import WCSSUB_SPECTRAL
 from astropy.nddata import StdDevUncertainty, InverseVariance, VarianceUncertainty
-from astropy.wcs.wcsapi.wrappers.base import BaseWCSWrapper
-from astropy.wcs.wcsapi import HighLevelWCSMixin, BaseHighLevelWCS
+from astropy.wcs.wcsapi import BaseHighLevelWCS
 from astropy.modeling import models
 
 from ndcube.wcs.wrappers import CompoundLowLevelWCS
@@ -41,11 +40,11 @@ class PaddedSpectrumWCS(CompoundLowLevelWCS):
     def __init__(self, spectral_wcs, n_extra_axes):
         self.spectral_wcs = spectral_wcs
         frame1 = CoordinateFrame(n_extra_axes, ['SPATIAL']*n_extra_axes,
-                                np.arange(n_extra_axes), unit=[u.pix]*n_extra_axes,
-                                name="Dummy1")
+                                 np.arange(n_extra_axes), unit=[u.pix]*n_extra_axes,
+                                 name="Dummy1")
         frame2 = CoordinateFrame(n_extra_axes, ['SPATIAL']*n_extra_axes,
-                                np.arange(n_extra_axes), unit=[u.pix]*n_extra_axes,
-                                name="Dummy2")
+                                 np.arange(n_extra_axes), unit=[u.pix]*n_extra_axes,
+                                 name="Dummy2")
         frame2frame = models.Multiply(1)
         if n_extra_axes > 1:
             for i in range(n_extra_axes-1):
@@ -128,7 +127,7 @@ class Specutils1DHandler:
 
         if statistic is None and isinstance(data.coords, PaddedSpectrumWCS):
             kwargs = {'wcs': data.coords.spectral_wcs}
-        elif statistic is None and  isinstance(data.coords, BaseHighLevelWCS):
+        elif statistic is None and isinstance(data.coords, BaseHighLevelWCS):
             kwargs = {'wcs': data.coords}
 
         elif statistic is not None:


### PR DESCRIPTION
## Description

If a 3D flux is input to a `Spectrum1D` along with a `spectral_axis` (rather than a full 3D WCS), the resulting object will have a spectral GWCS of only one dimension. Personally I think this behavior is not ideal and might need rethinking at some point, but in either case this fix will stop the translator from trying to swap axes on the WCS in this case, thus fixing (I hope) the bug @pllim ran into in https://github.com/spacetelescope/jdaviz/pull/1040#issuecomment-1018006578.

Fixes #60 