### PR TITLE
No longer test against casatools and casatasks

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,12 +26,11 @@ jobs:
       libraries: {}
       coverage: 'false'
 
-    - linux: py36-test-casa
+    - linux: py37-test
     - linux: py38-test
     - linux: py39-test
     - linux: py310-test-dev
 
-    - macos: py36-test-casa
     - windows: py37-test
     - macos: py38-test
     - windows: py39-test-dev

--- a/glue_astronomy/io/spectral_cube/tests/test_spectral_cube.py
+++ b/glue_astronomy/io/spectral_cube/tests/test_spectral_cube.py
@@ -12,7 +12,6 @@ def test_identifier_fits():
 
 
 def test_identifier_casa():
-    pytest.importorskip('casatools')
     assert is_spectral_cube(get_pkg_data_filename('data/cube_3d.image'))
 
 
@@ -38,7 +37,6 @@ def test_reader_fits_4d_fullstokes():
 
 
 def test_reader_casa():
-    pytest.importorskip('casatools')
     data = read_spectral_cube(get_pkg_data_filename('data/cube_3d.image'))
     assert isinstance(data['STOKES I'], np.ndarray)
     assert data.shape == (2, 3, 4)

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     glue-core>=1.0
     regions>=0.4
     specutils>=0.7
-    spectral-cube>=0.5.0
+    spectral-cube>=0.6.0
 
 [options.extras_require]
 docs =

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ long_description_content_type = text/x-rst
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.6
+python_requires = >=3.7
 setup_requires =
     setuptools_scm
 install_requires =

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,7 @@
 [tox]
-envlist = py{36,37,38,39,310}-{test,docs}-{casa,dev}
+envlist = py{36,37,38,39,310}-{test,docs}-{,dev}
 requires = pip >= 18.0
            setuptools >= 30.3.0
-indexserver =
-    NRAO = https://casa-pip.nrao.edu/repository/pypi-group/simple
 
 [testenv]
 passenv =
@@ -13,8 +11,6 @@ changedir =
 deps =
     dev: git+https://github.com/astropy/astropy
     dev: git+https://github.com/astropy/specutils
-    casa: :NRAO:casatools
-    casa: :NRAO:casatasks
 extras =
     test: test
     docs: docs


### PR DESCRIPTION
... since spectral-cube now depends on casa-formats-io by default

Fixes https://github.com/glue-viz/glue-astronomy/pull/65