### PR TITLE
Add publish job to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI Tests
+name: CI Workflows
 
 on:
   push:
@@ -36,3 +36,12 @@ jobs:
         - windows: py39-test-dev
         - macos: py310-test-dev
           PLAT: arm64
+
+  publish:
+    uses: OpenAstronomy/github-actions-workflows/.github/workflows/publish_pure_python.yml@v1
+    with:
+      test_extras: test
+      test_command: pytest --pyargs glue_astronomy
+    secrets:
+      pypi_token: ${{ secrets.pypi_token }}
+


### PR DESCRIPTION
## Description

Follow-up to #69 adding a `publish_pure_python` job.