### PR TITLE
translator for specreduce Trace objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,10 @@
-0.4.1 (unreleased)
+0.5.0 (unreleased)
 ------------------
 
 - Updated ``AstropyRegions`` translator to export ``roi.theta`` angle
   (supported as of ``glue`` 1.5.0). [#73]
+
+- Added support to import and export specreduce Trace objects. [#72]
 
 0.4.0 (2022-04-07)
 ------------------

--- a/docs/translators.rst
+++ b/docs/translators.rst
@@ -20,6 +20,9 @@ data classes. At this time, the following data classes are supported:
 * :class:`~astropy.nddata.CCDData` for spectra (from the `astropy.nddata
   <https://docs.astropy.org/en/stable/nddata/>`_ sub-package)
 
+* :class `~specreduce.tracing.Trace` for 2D spectral traces (from the `specreduce
+  <https://specreduce.readthedocs.io>`_ package)
+
 Working with these classes is described in `Datasets and subsets`_ below. In
 addition, this plugin defines ways for glue selections to be translated to
 Astropy `regions <https://astropy-regions.readthedocs.io>`_, as described in

--- a/glue_astronomy/translators/__init__.py
+++ b/glue_astronomy/translators/__init__.py
@@ -2,3 +2,4 @@ from . import ccddata  # noqa
 from . import regions  # noqa
 from . import spectral_cube  # noqa
 from . import spectrum1d  # noqa
+from . import trace # noqa

--- a/glue_astronomy/translators/tests/test_trace.py
+++ b/glue_astronomy/translators/tests/test_trace.py
@@ -1,0 +1,19 @@
+from specreduce import tracing
+from specreduce.utils.synth_data import make_2dspec_image
+
+from glue.core import Data, DataCollection
+
+
+def test_trace():
+
+    image = make_2dspec_image()
+    trace = tracing.FlatTrace(image, 5)
+
+    data_collection = DataCollection()
+
+    data_collection['trace'] = trace
+    data = data_collection['trace']
+    assert isinstance(data, Data)
+
+    trace_from_data = data.get_object()
+    assert isinstance(trace_from_data, tracing.FlatTrace)

--- a/glue_astronomy/translators/tests/test_trace.py
+++ b/glue_astronomy/translators/tests/test_trace.py
@@ -17,14 +17,14 @@ def test_trace():
     data_collection['trace'] = trace
     data = data_collection['trace']
     assert isinstance(data, Data)
-    assert np.all(data['y'] == trace.trace)
+    assert np.all(data['trace'] == trace.trace)
 
     trace_from_data = data.get_object()
     assert isinstance(trace_from_data, tracing.FlatTrace)
 
     # now edit the glue data object, this should now map to an ArrayTrace (instead of a FlatTrace)
     new_trace = np.ones_like(trace.trace)
-    data.update_components({data.get_component('y'): new_trace})
+    data.update_components({data.get_component('trace'): new_trace})
     trace_from_data = data.get_object()
     assert isinstance(trace_from_data, tracing.ArrayTrace)
     assert np.all(trace_from_data.trace == new_trace)

--- a/glue_astronomy/translators/tests/test_trace.py
+++ b/glue_astronomy/translators/tests/test_trace.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pytest
 
 from specreduce import tracing
 from specreduce.utils.synth_data import make_2dspec_image
@@ -14,8 +13,8 @@ def test_trace():
 
     data_collection = DataCollection()
 
-    data_collection['trace'] = trace
-    data = data_collection['trace']
+    data_collection['dc_trace'] = trace
+    data = data_collection['dc_trace']
     assert isinstance(data, Data)
     assert np.all(data['trace'] == trace.trace)
 
@@ -28,8 +27,3 @@ def test_trace():
     trace_from_data = data.get_object()
     assert isinstance(trace_from_data, tracing.ArrayTrace)
     assert np.all(trace_from_data.trace == new_trace)
-
-    # error raised if the x changes
-    data.update_components({data.get_component('x'): np.ones_like(trace.trace)})
-    with pytest.raises(ValueError):
-        trace_from_data = data.get_object()

--- a/glue_astronomy/translators/tests/test_trace.py
+++ b/glue_astronomy/translators/tests/test_trace.py
@@ -1,3 +1,6 @@
+import numpy as np
+import pytest
+
 from specreduce import tracing
 from specreduce.utils.synth_data import make_2dspec_image
 
@@ -14,7 +17,19 @@ def test_trace():
     data_collection['trace'] = trace
     data = data_collection['trace']
     assert isinstance(data, Data)
-    assert data['y'] == trace.trace
+    assert np.all(data['y'] == trace.trace)
 
     trace_from_data = data.get_object()
     assert isinstance(trace_from_data, tracing.FlatTrace)
+
+    # now edit the glue data object, this should now map to an ArrayTrace (instead of a FlatTrace)
+    new_trace = np.ones_like(trace.trace)
+    data.update_components({data.get_component('y'): new_trace})
+    trace_from_data = data.get_object()
+    assert isinstance(trace_from_data, tracing.ArrayTrace)
+    assert np.all(trace_from_data.trace == new_trace)
+
+    # error raised if the x changes
+    data.update_components({data.get_component('x'): np.ones_like(trace.trace)})
+    with pytest.raises(ValueError):
+        trace_from_data = data.get_object()

--- a/glue_astronomy/translators/tests/test_trace.py
+++ b/glue_astronomy/translators/tests/test_trace.py
@@ -14,6 +14,7 @@ def test_trace():
     data_collection['trace'] = trace
     data = data_collection['trace']
     assert isinstance(data, Data)
+    assert data['y'] == trace.trace
 
     trace_from_data = data.get_object()
     assert isinstance(trace_from_data, tracing.FlatTrace)

--- a/glue_astronomy/translators/trace.py
+++ b/glue_astronomy/translators/trace.py
@@ -1,0 +1,41 @@
+from glue.config import data_translator
+from glue.core import Data, Subset
+
+from specreduce.tracing import Trace
+
+
+@data_translator(Trace)
+class TraceHandler:
+
+    def to_data(self, obj):
+        """
+        Convert a specreduce Trace object to a glue Data object
+
+        Parameters
+        ----------
+        obj : `specreduce.tracing.Trace`
+            The Trace object to convert
+        """
+        data = Data(x=obj.image[0], y=obj.trace)
+        data.meta.update(obj.meta)
+        data.meta['Trace'] = obj
+        return data
+
+    def to_object(self, data, attribute=None):
+        """
+        Convert a glue Data object to a Trace object.
+
+        Parameters
+        ----------
+        data : `glue.core.data.Data`
+            The data to convert to a Trace object
+        attribute : `glue.core.component_id.ComponentID`
+            The attribute to use for the Trace data
+        """
+
+        if isinstance(data, Subset):
+            raise NotImplementedError("cannot convert subset to Trace object")
+        if not isinstance(data.meta.get('Trace'), Trace):
+            raise TypeError("data is not of a valid specreduce Trace object")
+
+        return data.meta['Trace']

--- a/glue_astronomy/translators/trace.py
+++ b/glue_astronomy/translators/trace.py
@@ -17,7 +17,8 @@ class TraceHandler:
             The Trace object to convert
         """
         data = Data(x=obj.image[0], y=obj.trace)
-        data.meta.update(obj.meta)
+        if hasattr(obj, 'meta'):
+            data.meta.update(obj.meta)
         data.meta['Trace'] = obj
         return data
 

--- a/glue_astronomy/translators/trace.py
+++ b/glue_astronomy/translators/trace.py
@@ -18,7 +18,7 @@ class TraceHandler:
         obj : `specreduce.tracing.Trace`
             The Trace object to convert
         """
-        data = Data(x=obj.image[0], trace=obj.trace)
+        data = Data(trace=obj.trace)
         if hasattr(obj, 'meta'):
             data.meta.update(obj.meta)
         data.meta['Trace'] = obj
@@ -42,11 +42,6 @@ class TraceHandler:
             raise TypeError("data is not of a valid specreduce Trace object")
 
         trace = data.meta['Trace']
-        trace_x = np.asarray(trace.image[0])
-        # NOTE: glue does not allow changing the shape of data components, so we can assume
-        # these arrays are still the appropriate length
-        if not np.all(trace_x == data['x']):
-            raise ValueError("x-values have changed")
         if not np.all(trace.trace[1] == data['trace']):
             trace = ArrayTrace(trace.image, data['trace'])
 

--- a/glue_astronomy/translators/trace.py
+++ b/glue_astronomy/translators/trace.py
@@ -18,7 +18,7 @@ class TraceHandler:
         obj : `specreduce.tracing.Trace`
             The Trace object to convert
         """
-        data = Data(x=obj.image[0], y=obj.trace)
+        data = Data(x=obj.image[0], trace=obj.trace)
         if hasattr(obj, 'meta'):
             data.meta.update(obj.meta)
         data.meta['Trace'] = obj
@@ -47,7 +47,7 @@ class TraceHandler:
         # these arrays are still the appropriate length
         if not np.all(trace_x == data['x']):
             raise ValueError("x-values have changed")
-        if not np.all(trace.trace[1] == data['y']):
-            trace = ArrayTrace(trace.image, data['y'])
+        if not np.all(trace.trace[1] == data['trace']):
+            trace = ArrayTrace(trace.image, data['trace'])
 
         return trace

--- a/glue_astronomy/translators/trace.py
+++ b/glue_astronomy/translators/trace.py
@@ -1,7 +1,9 @@
+import numpy as np
+
 from glue.config import data_translator
 from glue.core import Data, Subset
 
-from specreduce.tracing import Trace
+from specreduce.tracing import Trace, ArrayTrace
 
 
 @data_translator(Trace)
@@ -39,4 +41,13 @@ class TraceHandler:
         if not isinstance(data.meta.get('Trace'), Trace):
             raise TypeError("data is not of a valid specreduce Trace object")
 
-        return data.meta['Trace']
+        trace = data.meta['Trace']
+        trace_x = np.asarray(trace.image[0])
+        # NOTE: glue does not allow changing the shape of data components, so we can assume
+        # these arrays are still the appropriate length
+        if not np.all(trace_x == data['x']):
+            raise ValueError("x-values have changed")
+        if not np.all(trace.trace[1] == data['y']):
+            trace = ArrayTrace(trace.image, data['y'])
+
+        return trace

--- a/glue_astronomy/translators/trace.py
+++ b/glue_astronomy/translators/trace.py
@@ -37,9 +37,9 @@ class TraceHandler:
         """
 
         if isinstance(data, Subset):
-            raise NotImplementedError("cannot convert subset to Trace object")
+            raise NotImplementedError("Cannot convert subset to Trace object.")
         if not isinstance(data.meta.get('Trace'), Trace):
-            raise TypeError("data is not of a valid specreduce Trace object")
+            raise TypeError("data is not a valid specreduce Trace object.")
 
         trace = data.meta['Trace']
         if not np.all(trace.trace[1] == data['trace']):

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ install_requires =
     glue-core>=1.0
     regions>=0.4
     specutils>=0.7
+    specreduce>=1.0.0
     spectral-cube>=0.6.0
 
 [options.extras_require]


### PR DESCRIPTION
This PR implements a new translator for [specreduce Trace objects](https://specreduce.readthedocs.io/en/latest/#module-specreduce.tracing).  In doing so, it adds specreduce as a dependency.  In order to round-trip and retrieve the same underyling Trace object (instead of always having to export to an `ArrayTrace`), this currently saves a copy of the input Trace object in the `meta` of the glue `Data` object.  If this is not preferred, we could create an `ArrayTrace` from the glue `Data` object, but we'll likely still need to attach an instance or reference to the input data.