### PR TITLE
Export `roi.theta` in 'astropy-regions' translator and run passing tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.4.1 (unreleased)
+------------------
+
+- Updated ``AstropyRegions`` translator to export ``roi.theta`` angle
+  (supported as of ``glue`` 1.5.0). [#73]
+
 0.4.0 (2022-04-07)
 ------------------
 

--- a/glue_astronomy/translators/regions.py
+++ b/glue_astronomy/translators/regions.py
@@ -72,7 +72,7 @@ class AstropyRegionsHandler:
         if isinstance(subset_state, RoiSubsetState):
 
             roi = subset_state.roi
-            angle = (getattr(roi, 'theta', 0) * u.radian).to(u.deg)
+            angle = getattr(roi, 'theta', 0) * u.radian
             if isinstance(roi, RectangularROI):
                 xcen = 0.5 * (roi.xmin + roi.xmax)
                 ycen = 0.5 * (roi.ymin + roi.ymax)

--- a/glue_astronomy/translators/regions.py
+++ b/glue_astronomy/translators/regions.py
@@ -5,6 +5,7 @@ from glue.core.roi import (RectangularROI, PolygonalROI, CircularROI, PointROI,
                            RangeROI, AbstractMplRoi, EllipticalROI)
 from glue.viewers.image.pixel_selection_subset_state import PixelSubsetState
 
+from astropy import units as u
 from regions import (RectanglePixelRegion, PolygonPixelRegion, CirclePixelRegion,
                      PointPixelRegion, PixCoord, EllipsePixelRegion)
 
@@ -71,19 +72,20 @@ class AstropyRegionsHandler:
         if isinstance(subset_state, RoiSubsetState):
 
             roi = subset_state.roi
+            angle = (getattr(roi, 'theta', 0) * u.radian).to(u.deg)
             if isinstance(roi, RectangularROI):
                 xcen = 0.5 * (roi.xmin + roi.xmax)
                 ycen = 0.5 * (roi.ymin + roi.ymax)
                 width = roi.xmax - roi.xmin
                 height = roi.ymax - roi.ymin
-                return RectanglePixelRegion(PixCoord(xcen, ycen), width, height)
+                return RectanglePixelRegion(PixCoord(xcen, ycen), width, height, angle=angle)
             elif isinstance(roi, PolygonalROI):
                 return PolygonPixelRegion(PixCoord(roi.vx, roi.vy))
             elif isinstance(roi, CircularROI):
                 return CirclePixelRegion(PixCoord(*roi.get_center()), roi.get_radius())
             elif isinstance(roi, EllipticalROI):
                 return EllipsePixelRegion(
-                    PixCoord(roi.xc, roi.yc), roi.radius_x * 2, roi.radius_y * 2)
+                    PixCoord(roi.xc, roi.yc), roi.radius_x * 2, roi.radius_y * 2, angle=angle)
             elif isinstance(roi, PointROI):
                 return PointPixelRegion(PixCoord(*roi.center()))
             elif isinstance(roi, RangeROI):

--- a/glue_astronomy/translators/tests/test_regions.py
+++ b/glue_astronomy/translators/tests/test_regions.py
@@ -3,6 +3,7 @@ import numpy as np
 from astropy import units as u
 from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
+from packaging.version import Version
 
 from regions import (RectanglePixelRegion, PolygonPixelRegion, CirclePixelRegion,
                      EllipsePixelRegion, PointPixelRegion, CompoundPixelRegion, PixCoord)
@@ -78,7 +79,7 @@ class TestAstropyRegions:
     @pytest.mark.parametrize('theta', (0, 0.1, -0.5 * np.pi))
     def test_ellipse_roi(self, theta):
 
-        if theta != 0 and tuple(glue_version.split('.')[:2]) < ('1', '5'):
+        if theta != 0 and Version(glue_version) < Version('1.5'):
             with pytest.raises(NotImplementedError, match='Rotated ellipses are not yet supported'):
                 RoiSubsetState(self.data.pixel_component_ids[1],
                                self.data.pixel_component_ids[0],

--- a/glue_astronomy/translators/tests/test_regions.py
+++ b/glue_astronomy/translators/tests/test_regions.py
@@ -371,42 +371,31 @@ class TestAstropyRegions:
         assert reg.contains(PixCoord(2.75, 4.75))
         assert not reg.contains(PixCoord(5, 7))
 
-    # The following test fails because the logical operations should now work?
-
-    @pytest.mark.xfail
-    def test_invalid_combos(self):
-        good_subset = RoiSubsetState(self.data.pixel_component_ids[1],
-                                     self.data.pixel_component_ids[0],
-                                     RectangularROI(1, 5, 2, 6))
-        bad_subset = RoiSubsetState(self.data.pixel_component_ids[1],
-                                    self.data.main_components[0],
-                                    CircularROI(4.75, 5.75, 0.5))
-        and_sub = AndState(good_subset, bad_subset)
-        or_sub = OrState(good_subset, bad_subset)
-        xor_sub = XorState(good_subset, bad_subset)
-        multior = MultiOrState([good_subset, bad_subset])
+    def test_main_component_combos(self):
+        pci_subset = RoiSubsetState(self.data.pixel_component_ids[1],
+                                    self.data.pixel_component_ids[0],
+                                    RectangularROI(1, 5, 2, 6))
+        main_subset = RoiSubsetState(self.data.pixel_component_ids[1],
+                                     self.data.main_components[0],
+                                     CircularROI(4.75, 5.75, 0.5))
+        and_sub = AndState(pci_subset, main_subset)
+        or_sub = OrState(pci_subset, main_subset)
+        xor_sub = XorState(pci_subset, main_subset)
+        multior = MultiOrState([pci_subset, main_subset])
         self.dc.new_subset_group(subset_state=and_sub, label='and')
         self.dc.new_subset_group(subset_state=or_sub, label='or')
         self.dc.new_subset_group(subset_state=xor_sub, label='xor')
         self.dc.new_subset_group(subset_state=multior, label='multior')
 
-        expected_error = 'Subset state yatt should be y pixel coordinate'
+        and_region = self.data.get_selection_definition(subset_id='and', format='astropy-regions')
+        or_region = self.data.get_selection_definition(subset_id='or', format='astropy-regions')
+        xor_region = self.data.get_selection_definition(subset_id='xor', format='astropy-regions')
+        multior_region = self.data.get_selection_definition(subset_id='multior', format='astropy-regions')
 
-        with pytest.raises(ValueError) as exc:
-            self.data.get_selection_definition(subset_id='and', format='astropy-regions')
-        assert exc.value.args[0] == expected_error
-
-        with pytest.raises(ValueError) as exc:
-            self.data.get_selection_definition(subset_id='or', format='astropy-regions')
-        assert exc.value.args[0] == expected_error
-
-        with pytest.raises(ValueError) as exc:
-            self.data.get_selection_definition(subset_id='xor', format='astropy-regions')
-        assert exc.value.args[0] == expected_error
-
-        with pytest.raises(ValueError) as exc:
-            self.data.get_selection_definition(subset_id='multior', format='astropy-regions')
-        assert exc.value.args[0] == expected_error
+        for reg in and_region, or_region, xor_region, multior_region:
+            assert isinstance(reg, CompoundPixelRegion)
+            assert isinstance(reg.region1, RectanglePixelRegion)
+            assert isinstance(reg.region2, CirclePixelRegion)
 
     def test_reordered_pixel_components(self):
         self.data._pixel_component_ids = self.data._pixel_component_ids[::-1]

--- a/glue_astronomy/translators/tests/test_regions.py
+++ b/glue_astronomy/translators/tests/test_regions.py
@@ -390,7 +390,8 @@ class TestAstropyRegions:
         and_region = self.data.get_selection_definition(subset_id='and', format='astropy-regions')
         or_region = self.data.get_selection_definition(subset_id='or', format='astropy-regions')
         xor_region = self.data.get_selection_definition(subset_id='xor', format='astropy-regions')
-        multior_region = self.data.get_selection_definition(subset_id='multior', format='astropy-regions')
+        multior_region = self.data.get_selection_definition(subset_id='multior',
+                                                            format='astropy-regions')
 
         for reg in and_region, or_region, xor_region, multior_region:
             assert isinstance(reg, CompoundPixelRegion)


### PR DESCRIPTION
## Description

As of 1.5.0 `glue` supports rotation angles in ROIs, breaking the `NotImplementedError` test.
This is updating the test and exporting the rotation angle `theta`, if set, to Astropy `regions` created from an ROI.
Also removed the `pytest.raises` for the no longer failing logical operations in `test_invalid_combos`.