### PR TITLE
Return empty string instead of crashing when UCD_TO_SPECTRAL_NAME lookup failed

### DIFF
--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -114,7 +114,8 @@ class PaddedSpectrumWCS(BaseWCSWrapper, HighLevelWCSMixin):
         else:
             names = [f"Offset{i}" for i in range(0, self.flux_ndim-1)]
 
-        return UCD_TO_SPECTRAL_NAME.get(self.spectral_wcs.world_axis_physical_types[0], ''), *names
+        return (UCD_TO_SPECTRAL_NAME.get(self.spectral_wcs.world_axis_physical_types[0], ''),
+                *names)
 
     @property
     def axis_correlation_matrix(self):

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -114,7 +114,7 @@ class PaddedSpectrumWCS(BaseWCSWrapper, HighLevelWCSMixin):
         else:
             names = [f"Offset{i}" for i in range(0, self.flux_ndim-1)]
 
-        return (UCD_TO_SPECTRAL_NAME[self.spectral_wcs.world_axis_physical_types[0]], *names)
+        return (UCD_TO_SPECTRAL_NAME.get(self.spectral_wcs.world_axis_physical_types[0], ''), *names)  # noqa: E501
 
     @property
     def axis_correlation_matrix(self):

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -114,7 +114,7 @@ class PaddedSpectrumWCS(BaseWCSWrapper, HighLevelWCSMixin):
         else:
             names = [f"Offset{i}" for i in range(0, self.flux_ndim-1)]
 
-        return (UCD_TO_SPECTRAL_NAME.get(self.spectral_wcs.world_axis_physical_types[0], ''), *names)  # noqa: E501
+        return UCD_TO_SPECTRAL_NAME.get(self.spectral_wcs.world_axis_physical_types[0], ''), *names
 
     @property
     def axis_correlation_matrix(self):


### PR DESCRIPTION
## Description

Without this patch, loading an uncalibrated 2D spectrum without wavelength axis will crash.