### PR TITLE
BUG: Parse units for Spectrum1D for all occasions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+0.5.1 (unreleased)
+------------------
+
+- Fixed unit parsing for ``Specutils1DHandler.to_data`` so it no longer
+  drops the flux unit in some cases. [#78]
+
 0.5.0 (2022-08-18)
 ------------------
 

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -134,21 +134,15 @@ class Specutils1DHandler:
         # Glue expects spectral axis first for cubes (opposite of specutils).
         # Swap the spectral axis to first here. to_object doesn't need this because
         # Spectrum1D does it automatically on initialization.
-        if obj.flux.ndim > 1:
-            if obj.wcs.world_n_dim == 1:
-                data = Data(coords=PaddedSpectrumWCS(obj.wcs, obj.flux.ndim))
-                data['flux'] = obj.flux
-            else:
-                data = Data(coords=obj.wcs)
-                data['flux'] = obj.flux
-                data.get_component('flux').units = str(obj.unit)
+        if obj.flux.ndim > 1 and obj.wcs.world_n_dim == 1:
+            data = Data(coords=PaddedSpectrumWCS(obj.wcs, obj.flux.ndim))
+        elif obj.flux.ndim == 1 and obj.wcs.world_n_dim == 1 and isinstance(obj.wcs, GWCS):
+            data = Data(coords=SpectralCoordinates(obj.spectral_axis))
         else:
-            if obj.wcs.world_n_dim == 1 and isinstance(obj.wcs, GWCS):
-                data = Data(coords=SpectralCoordinates(obj.spectral_axis))
-            else:
-                data = Data(coords=obj.wcs)
-            data['flux'] = obj.flux
-            data.get_component('flux').units = str(obj.unit)
+            data = Data(coords=obj.wcs)
+
+        data['flux'] = obj.flux
+        data.get_component('flux').units = str(obj.unit)
 
         # Include uncertainties if they exist
         if obj.uncertainty is not None:

--- a/glue_astronomy/translators/tests/test_spectrum1d.py
+++ b/glue_astronomy/translators/tests/test_spectrum1d.py
@@ -236,6 +236,7 @@ def test_spectrum1d_2d_data(spec_ndim):
     assert len(data.main_components) == 1
     assert data.main_components[0].label == 'flux'
     assert_allclose(data['flux'], flux.value)
+    assert data.get_component('flux').units == 'Jy'
 
     assert data.coords.pixel_n_dim == spec_ndim
     assert data.coords.world_n_dim == spec_ndim


### PR DESCRIPTION
Parse units for Spectrum1D for all occasions. We need this so flux unit is shown correctly in Jdaviz for 2D and 3D spectra. Fix https://github.com/spacetelescope/jdaviz/issues/1625

We also need this for https://github.com/spacetelescope/jdaviz/pull/1608

Also simplify Spectrum1D parser logic.

cc @dhomeier @astrofrog 

[🐱](https://jira.stsci.edu/browse/JDAT-2723)