### PR TITLE
Fixed return type and shape for pixel <-> world conversions in SpectralCoordinates

### DIFF
--- a/glue_astronomy/spectral_coordinates.py
+++ b/glue_astronomy/spectral_coordinates.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from astropy.units import Quantity
 from glue.core.coordinates import Coordinates
 
 __all__ = ['SpectralCoordinates']
@@ -12,6 +13,8 @@ class SpectralCoordinates(Coordinates):
     """
 
     def __init__(self, values):
+        if not isinstance(values, Quantity):
+            raise TypeError('values should be a Quantity instance')
         self._index = np.arange(len(values))
         self._values = values
         super().__init__(n_dim=1)
@@ -32,8 +35,11 @@ class SpectralCoordinates(Coordinates):
         Returns
         -------
         """
-        return tuple(np.interp(world, self._values.value, self._index,
-                               left=np.nan, right=np.nan))
+        if len(world) > 1:
+            raise ValueError('SpectralCoordinates is a 1-d coordinate class '
+                             'and only accepts a single scalar or array to convert')
+        return np.interp(world[0], self._values.value, self._index,
+                         left=np.nan, right=np.nan)
 
     def pixel_to_world_values(self, *pixel):
         """
@@ -43,5 +49,8 @@ class SpectralCoordinates(Coordinates):
         Returns
         -------
         """
-        return tuple(np.interp(pixel, self._index, self._values.value,
-                               left=np.nan, right=np.nan))
+        if len(pixel) > 1:
+            raise ValueError('SpectralCoordinates is a 1-d coordinate class '
+                             'and only accepts a single scalar or array to convert')
+        return np.interp(pixel[0], self._index, self._values.value,
+                         left=np.nan, right=np.nan)

--- a/glue_astronomy/tests/test_spectral_coordinates.py
+++ b/glue_astronomy/tests/test_spectral_coordinates.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 from astropy import units as u
-from numpy.testing import assert_equal, assert_allclose
+from numpy.testing import assert_allclose
 from glue_astronomy.spectral_coordinates import SpectralCoordinates
 
 

--- a/glue_astronomy/tests/test_spectral_coordinates.py
+++ b/glue_astronomy/tests/test_spectral_coordinates.py
@@ -1,0 +1,35 @@
+import pytest
+import numpy as np
+from astropy import units as u
+from numpy.testing import assert_equal, assert_allclose
+from glue_astronomy.spectral_coordinates import SpectralCoordinates
+
+
+def test_basic():
+
+    sc = SpectralCoordinates([10, 20, 30] * u.Hz)
+
+    assert_allclose(sc.pixel_to_world_values(0), 10)
+    assert_allclose(sc.pixel_to_world_values([0, 1]), [10, 20])
+    assert_allclose(sc.pixel_to_world_values([-0.5, 0, 0.5, 1, 10]),
+                    [np.nan, 10, 15, 20, np.nan])
+
+    assert_allclose(sc.world_to_pixel_values(10), 0)
+    assert_allclose(sc.world_to_pixel_values([10, 15, 20]), [0, 0.5, 1.0])
+
+
+def test_invalid_init():
+
+    with pytest.raises(TypeError, match='values should be a Quantity instance'):
+        SpectralCoordinates([10, 20, 30])
+
+
+def test_invalid_conversion():
+
+    sc = SpectralCoordinates([10, 20, 30] * u.Hz)
+
+    with pytest.raises(ValueError, match='SpectralCoordinates is a 1-d coordinate class'):
+        sc.pixel_to_world_values(1, 2)
+
+    with pytest.raises(ValueError, match='SpectralCoordinates is a 1-d coordinate class'):
+        sc.world_to_pixel_values(1, 2)

--- a/glue_astronomy/translators/tests/test_spectrum1d.py
+++ b/glue_astronomy/translators/tests/test_spectrum1d.py
@@ -93,7 +93,7 @@ def test_to_spectrum1d_with_spectral_coordinates():
     data.add_component(Component(np.array([3, 4, 5]), units='Jy'), 'x')
 
     assert_allclose(data.coords.pixel_to_world_values([0, 0.5, 1, 1.5, 2]),
-                    [[1, 2.5, 4, 7, 10]])
+                    [1, 2.5, 4, 7, 10])
 
     spec = data.get_object(Spectrum1D, attribute=data.id['x'])
     assert_quantity_allclose(spec.spectral_axis, [1, 4, 10] * u.micron)


### PR DESCRIPTION
The pixel <-> world methods should return single scalars/arrays not tuples in order to be APE-14-compliant.