### PR TITLE
Require glue-core >= 1.6.1, dropped Python 3.7 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,13 +33,12 @@ jobs:
 
       envs: |
         # Standard tests
-        - linux: py37-test
         - linux: py38-test
         - linux: py39-test
         - linux: py310-test-dev
         - linux: py311-test-dev
 
-        - macos: py37-test
+        - macos: py311-test
         - windows: py38-test
         - windows: py39-test-dev
         - macos: py310-test-dev

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ long_description_content_type = text/x-rst
 [options]
 zip_safe = False
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires =
     setuptools_scm
 install_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ setup_requires =
     setuptools_scm
 install_requires =
     astropy>=4.0
-    glue-core>=1.0
+    glue-core>=1.6.1
     regions>=0.4
     specutils>=0.7
     specreduce>=1.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311}-{test,docs,codestyle}-{dev}
+envlist = py{38,39,310,311}-{test,docs,codestyle}-{dev}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 


### PR DESCRIPTION
glue-astronomy is now only compatible with glue-core 1.6.1 or later. Also see:

* https://github.com/spacetelescope/jdaviz/issues/1974

This is because https://github.com/glue-viz/glue-astronomy/pull/82 was released as part of glue-astronomy 0.6.0 and it requires https://github.com/glue-viz/glue/pull/2345 that was released as part of glue-core 1.6.1

cc @astrofrog and @dhomeier 
