### PR TITLE
Accept `component.units=None` in translators input

### DIFF
--- a/glue_astronomy/translators/nddata.py
+++ b/glue_astronomy/translators/nddata.py
@@ -126,7 +126,7 @@ class CCDDataHandler(NDDataArrayHandler):
 
         values = data.get_data(attribute)
         values, mask = _get_value_and_mask(subset_state, data, values)
-        values = values * u.Unit(component.units)
+        values = u.Quantity(values, unit=component.units)
 
         if has_fitswcs:
             result = CCDData(values, mask=mask, wcs=wcs, meta=data.meta)

--- a/glue_astronomy/translators/spectral_cube.py
+++ b/glue_astronomy/translators/spectral_cube.py
@@ -73,7 +73,7 @@ class SpectralCubeHandler:
             values = values.copy()
             mask = BooleanArrayMask(mask, wcs=wcs)
 
-        values = values * u.Unit(component.units)
+        values = u.Quantity(values, unit=component.units)
 
         # Drop Stokes axis if there is one for FITS WCS
         if isinstance(wcs, WCS) and wcs.sub([WCSSUB_STOKES]).naxis > 0:

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -267,7 +267,7 @@ class Specutils1DHandler:
                 if attribute_label not in ('flux', 'uncertainty'):
                     attribute_label = 'flux'
 
-                values = values * u.Unit(component.units)
+                values = u.Quantity(values, unit=component.units)
 
                 # If the attribute is uncertainty, we must coerce it to a
                 #  specific uncertainty type. If no value exists in the glue


### PR DESCRIPTION
## Description

To fix support for glue-viz/glue#2296.
Other uses of `component.units` in the translators (`NDDataArray`, `StdDevUncertainty`) already accept `unit=None`, so it seems most sensible to switch to the `u.Quantity()` format here.
Added glue to devdeps to test this (might be a good idea in general?)