### PR TITLE
Adding support for uncertainty extraction to NDDataArray

### DIFF
--- a/glue_astronomy/translators/nddata.py
+++ b/glue_astronomy/translators/nddata.py
@@ -8,7 +8,7 @@ from glue.config import data_translator
 from glue.core import Data, Subset
 from glue.core.coordinates import Coordinates
 
-from .spectrum1d import SpectralCoordinates
+from .spectrum1d import SpectralCoordinates, UNCERT_REF
 
 
 def _get_attribute(attribute, data):
@@ -56,9 +56,8 @@ class NDDataArrayHandler:
         data['data'] = obj.data
         data.get_component('data').units = str(obj.unit)
         if obj.uncertainty is not None:
-            data['uncertainty'] = getattr(
-                obj.uncertainty, 'array', obj.uncertainty
-            )
+            uncert = obj.uncertainty.represent_as(StdDevUncertainty)
+            data['uncertainty'] = uncert.array
         data.meta.update(obj.meta)
         return data
 
@@ -96,9 +95,12 @@ class NDDataArrayHandler:
         values, mask = _get_value_and_mask(subset_state, data, values)
 
         if 'uncertainty' in component_labels:
-            uncertainty = StdDevUncertainty(
+            uncert_cls = UNCERT_REF[
+                data.meta.get('uncertainty_type', 'std')
+            ]
+            uncertainty = uncert_cls(
                 data.get_component('uncertainty').data
-            )
+            ).represent_as(StdDevUncertainty)
         else:
             uncertainty = None
 

--- a/glue_astronomy/translators/tests/test_nddata.py
+++ b/glue_astronomy/translators/tests/test_nddata.py
@@ -136,6 +136,22 @@ def test_from_nddata(cls, kwargs, data_attr):
     assert image_new.unit is u.Jy
 
 
+def test_nddata_uncertainty():
+    data = [[2, 3], [4, 5]] * u.Jy
+    uncertainty = StdDevUncertainty(np.ones_like(data))
+    spec = NDDataArray(
+        data=data,
+        uncertainty=uncertainty
+    )
+    data_collection = DataCollection()
+    data_collection['data'] = spec
+
+    data = data_collection['data']
+    spec_new = data.get_object(NDDataArray)
+    assert isinstance(spec_new.uncertainty, StdDevUncertainty)
+    assert_equal(spec_new.uncertainty.array, uncertainty.array)
+
+
 @pytest.mark.parametrize('with_wcs', (False, True))
 def test_from_ccddata(with_wcs):
 

--- a/glue_astronomy/translators/tests/test_nddata.py
+++ b/glue_astronomy/translators/tests/test_nddata.py
@@ -4,7 +4,9 @@ from numpy.testing import assert_allclose, assert_equal
 
 from astropy import units as u
 from astropy.nddata import CCDData, NDDataArray
-from astropy.nddata.nduncertainty import StdDevUncertainty
+from astropy.nddata.nduncertainty import (
+    StdDevUncertainty, VarianceUncertainty, InverseVariance
+)
 from astropy.wcs import WCS
 
 from glue.core import Data, DataCollection
@@ -136,7 +138,11 @@ def test_from_nddata(cls, kwargs, data_attr):
     assert image_new.unit is u.Jy
 
 
-@pytest.mark.parametrize('uncertainty_type', (StdDevUncertainty, VarianceUncertainty, InverseVariance))
+@pytest.mark.parametrize(
+    'uncertainty_type', (
+            StdDevUncertainty, VarianceUncertainty, InverseVariance
+    )
+)
 def test_nddata_uncertainty(uncertainty_type):
     data = [[2, 3], [4, 5]] * u.Jy
     uncertainty = uncertainty_type(np.ones_like(data.value))
@@ -150,7 +156,7 @@ def test_nddata_uncertainty(uncertainty_type):
     data = data_collection['data']
     spec_new = data.get_object(NDDataArray)
     assert isinstance(spec_new.uncertainty, StdDevUncertainty)
-    if  isinstance(uncertainty, StdDevUncertainty):
+    if isinstance(uncertainty, StdDevUncertainty):
         assert_equal(spec_new.uncertainty.array, uncertainty.array)
     else:
         assert_equal(spec_new.uncertainty.array, uncertainty.represent_as(StdDevUncertainty).array)

--- a/glue_astronomy/translators/tests/test_nddata.py
+++ b/glue_astronomy/translators/tests/test_nddata.py
@@ -136,9 +136,10 @@ def test_from_nddata(cls, kwargs, data_attr):
     assert image_new.unit is u.Jy
 
 
-def test_nddata_uncertainty():
+@pytest.mark.parametrize('uncertainty_type', (StdDevUncertainty, VarianceUncertainty, InverseVariance))
+def test_nddata_uncertainty(uncertainty_type):
     data = [[2, 3], [4, 5]] * u.Jy
-    uncertainty = StdDevUncertainty(np.ones_like(data))
+    uncertainty = uncertainty_type(np.ones_like(data.value))
     spec = NDDataArray(
         data=data,
         uncertainty=uncertainty
@@ -149,7 +150,10 @@ def test_nddata_uncertainty():
     data = data_collection['data']
     spec_new = data.get_object(NDDataArray)
     assert isinstance(spec_new.uncertainty, StdDevUncertainty)
-    assert_equal(spec_new.uncertainty.array, uncertainty.array)
+    if  isinstance(uncertainty, StdDevUncertainty):
+        assert_equal(spec_new.uncertainty.array, uncertainty.array)
+    else:
+        assert_equal(spec_new.uncertainty.array, uncertainty.represent_as(StdDevUncertainty).array)
 
 
 @pytest.mark.parametrize('with_wcs', (False, True))


### PR DESCRIPTION
In #81, I added translators for objects in `astropy.nddata`. In this PR, I add support for extracting uncertainties from glue `Data` objects and translating them into the `uncertainty` attr in `NDDataArray` objects. This was missing in the previous PR, but should have been there.