### PR TITLE
Fix Spectrum1D translator handling of 1D spectra with spectral-only axes

### DIFF
--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -136,7 +136,11 @@ class Specutils1DHandler:
         # Spectrum1D does it automatically on initialization.
         if obj.flux.ndim > 1 and obj.wcs.world_n_dim == 1:
             data = Data(coords=PaddedSpectrumWCS(obj.wcs, obj.flux.ndim))
-        elif obj.flux.ndim == 1 and obj.wcs.world_n_dim == 1 and isinstance(obj.wcs, GWCS):
+        elif (
+            (obj.flux.ndim == 1 and obj.wcs.world_n_dim == 1) and
+            (getattr(obj.wcs, 'is_spectral', False) or
+             isinstance(obj.wcs, GWCS))
+        ):
             data = Data(coords=SpectralCoordinates(obj.spectral_axis))
         else:
             data = Data(coords=obj.wcs)

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -3,8 +3,6 @@ import numpy as np
 from glue.config import data_translator
 from glue.core import Data, Subset
 
-from gwcs import WCS as GWCS
-
 from astropy.wcs import WCS
 from astropy import units as u
 from astropy.wcs import WCSSUB_SPECTRAL
@@ -133,14 +131,11 @@ class Specutils1DHandler:
 
         # Glue expects spectral axis first for cubes (opposite of specutils).
         # Swap the spectral axis to first here. to_object doesn't need this because
-        # Spectrum1D does it automatically on initialization.
-        if obj.flux.ndim > 1 and obj.wcs.world_n_dim == 1:
+        # glue needs WCS to be padded to the dimensionality of the flux; for 1D
+        # flux this is not required, but provides additional to `data.coords`.
+        if (obj.flux.ndim > 1 or isinstance(obj.wcs, WCS)) and obj.wcs.world_n_dim == 1:
             data = Data(coords=PaddedSpectrumWCS(obj.wcs, obj.flux.ndim))
-        elif (
-            (obj.flux.ndim == 1 and obj.wcs.world_n_dim == 1) and
-            (getattr(obj.wcs, 'is_spectral', False) or
-             isinstance(obj.wcs, GWCS))
-        ):
+        elif obj.flux.ndim == 1 and obj.wcs.world_n_dim == 1:
             data = Data(coords=SpectralCoordinates(obj.spectral_axis))
         else:
             data = Data(coords=obj.wcs)

--- a/glue_astronomy/translators/spectrum1d.py
+++ b/glue_astronomy/translators/spectrum1d.py
@@ -129,8 +129,6 @@ class Specutils1DHandler:
 
     def to_data(self, obj):
 
-        # Glue expects spectral axis first for cubes (opposite of specutils).
-        # Swap the spectral axis to first here. to_object doesn't need this because
         # glue needs WCS to be padded to the dimensionality of the flux; for 1D
         # flux this is not required, but provides additional to `data.coords`.
         if (obj.flux.ndim > 1 or isinstance(obj.wcs, WCS)) and obj.wcs.world_n_dim == 1:


### PR DESCRIPTION
The glue-astronomy translator generates glue `Data` objets from `Spectrum1D` with special treatment of the WCS coordinates. The current translator only produces a coordinate via `SpectralCoordinates` in the case where there's:

1. a 1D spectrum with 1D fluxes
2. WCS with one world dimension
3. *and* the WCS is an instance of `gwcs.WCS`. 

I'm working with a use-case (https://github.com/spacetelescope/jdaviz/pull/2039) with a single non-gwcs spectral axis. In this PR, I've simply allowed non-gwcs axes to pass through if it is clearly marked as a spectral axis, and meets criteria 1 and 2.