### PR TITLE
FEAT: Support sky regions and allow direct call to translator function

### DIFF
--- a/glue_astronomy/translators/regions.py
+++ b/glue_astronomy/translators/regions.py
@@ -220,7 +220,8 @@ class AstropyRegionsHandler:
                                  'pixel coordinate')
             if len(subset_state.pairs) == 0:
                 raise ValueError('Multirange subset state should contain at least one range')
-            region = range_to_rect(subset.data, ori, subset_state.pairs[0][0], subset_state.pairs[0][1])
+            region = range_to_rect(
+                subset.data, ori, subset_state.pairs[0][0], subset_state.pairs[0][1])
             for pair in subset_state.pairs[1:]:
                 region = region | range_to_rect(subset.data, ori, pair[0], pair[1])
             return region

--- a/glue_astronomy/translators/regions.py
+++ b/glue_astronomy/translators/regions.py
@@ -12,7 +12,7 @@ from regions import (RectanglePixelRegion, PolygonPixelRegion, CirclePixelRegion
                      PointPixelRegion, PixCoord, EllipsePixelRegion,
                      AnnulusPixelRegion, CircleAnnulusPixelRegion)
 
-__all__ = ["range_to_rect", "roi_subset_state_to_spatial", "AstropyRegionsHandler"]
+__all__ = ["range_to_rect", "roi_subset_state_to_region", "AstropyRegionsHandler"]
 
 GLUE_LT_1_11 = Version(glue_version) < Version('1.11')
 
@@ -53,7 +53,7 @@ def range_to_rect(data, ori, low, high):
     return RectanglePixelRegion(PixCoord(xcen, ycen), width, height)
 
 
-def roi_subset_state_to_spatial(subset_state, to_sky=False):
+def roi_subset_state_to_region(subset_state, to_sky=False):
     """Translate the given ``RoiSubsetState`` containing ROI
     that is compatible with 2D spatial regions to proper
     ``regions`` shape. If ``to_sky=True`` is given, it will
@@ -198,7 +198,7 @@ class AstropyRegionsHandler:
                         f"ROIs of type {roi.__class__.__name__} are not yet supported")
 
             else:
-                return roi_subset_state_to_spatial(subset_state)
+                return roi_subset_state_to_region(subset_state)
 
         elif isinstance(subset_state, RangeSubsetState):
             x_pix_att, y_pix_att = _get_xy_pix_att_from_subset(subset)

--- a/glue_astronomy/translators/tests/test_regions.py
+++ b/glue_astronomy/translators/tests/test_regions.py
@@ -21,7 +21,7 @@ from glue.viewers.image.pixel_selection_subset_state import PixelSubsetState
 from glue import __version__ as glue_version
 
 from glue_astronomy.translators.regions import (_annulus_to_subset_state, GLUE_LT_1_11,
-                                                roi_subset_state_to_spatial)
+                                                roi_subset_state_to_region)
 from glue_astronomy.translators.tests.test_nddata import WCS_CELESTIAL
 
 
@@ -49,7 +49,7 @@ class TestAstropyRegions:
         assert_allclose(reg.width, 2.5)
         assert_allclose(reg.height, 3.5)
 
-        reg_sky = roi_subset_state_to_spatial(subset_state, to_sky=True)
+        reg_sky = roi_subset_state_to_region(subset_state, to_sky=True)
         assert isinstance(reg_sky, RectangleSkyRegion)
 
     def test_polygonal_roi(self):

--- a/glue_astronomy/translators/tests/test_regions.py
+++ b/glue_astronomy/translators/tests/test_regions.py
@@ -5,7 +5,8 @@ from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 from packaging.version import Version
 
-from regions import (RectanglePixelRegion, RectangleSkyRegion, PolygonPixelRegion, CirclePixelRegion,
+from regions import (RectanglePixelRegion, RectangleSkyRegion,
+                     PolygonPixelRegion, CirclePixelRegion,
                      EllipsePixelRegion, PointPixelRegion, CompoundPixelRegion,
                      CircleAnnulusPixelRegion, PixCoord)
 

--- a/glue_astronomy/translators/tests/test_regions.py
+++ b/glue_astronomy/translators/tests/test_regions.py
@@ -5,7 +5,7 @@ from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 from packaging.version import Version
 
-from regions import (RectanglePixelRegion, PolygonPixelRegion, CirclePixelRegion,
+from regions import (RectanglePixelRegion, RectangleSkyRegion, PolygonPixelRegion, CirclePixelRegion,
                      EllipsePixelRegion, PointPixelRegion, CompoundPixelRegion,
                      CircleAnnulusPixelRegion, PixCoord)
 
@@ -20,13 +20,15 @@ from glue.viewers.image.pixel_selection_subset_state import PixelSubsetState
 from glue import __version__ as glue_version
 
 from glue_astronomy.translators.regions import (_annulus_to_subset_state, GLUE_LT_1_11,
-                                                AstropyRegionsHandler)
+                                                roi_subset_state_to_spatial)
+from glue_astronomy.translators.tests.test_nddata import WCS_CELESTIAL
 
 
 class TestAstropyRegions:
 
     def setup_method(self, method):
         self.data = Data(flux=np.ones((128, 256)))  # ny, nx
+        self.data.coords = WCS_CELESTIAL
         self.dc = DataCollection([self.data])
 
     def test_rectangular_roi(self):
@@ -46,14 +48,8 @@ class TestAstropyRegions:
         assert_allclose(reg.width, 2.5)
         assert_allclose(reg.height, 3.5)
 
-        # Test direct call to handler
-        handler = AstropyRegionsHandler()
-        reg_2 = handler.to_object(subset_state)
-        assert isinstance(reg_2, RectanglePixelRegion)
-        assert_allclose(reg_2.center.x, 2.25)
-        assert_allclose(reg_2.center.y, 1.55)
-        assert_allclose(reg_2.width, 2.5)
-        assert_allclose(reg_2.height, 3.5)
+        reg_sky = roi_subset_state_to_spatial(subset_state, to_sky=True)
+        assert isinstance(reg_sky, RectangleSkyRegion)
 
     def test_polygonal_roi(self):
 

--- a/glue_astronomy/translators/tests/test_regions.py
+++ b/glue_astronomy/translators/tests/test_regions.py
@@ -19,7 +19,8 @@ from glue.core.subset import (RoiSubsetState, RangeSubsetState, OrState,
 from glue.viewers.image.pixel_selection_subset_state import PixelSubsetState
 from glue import __version__ as glue_version
 
-from glue_astronomy.translators.regions import _annulus_to_subset_state, GLUE_LT_1_10_1
+from glue_astronomy.translators.regions import (_annulus_to_subset_state, GLUE_LT_1_11,
+                                                AstropyRegionsHandler)
 
 
 class TestAstropyRegions:
@@ -44,6 +45,15 @@ class TestAstropyRegions:
         assert_allclose(reg.center.y, 1.55)
         assert_allclose(reg.width, 2.5)
         assert_allclose(reg.height, 3.5)
+
+        # Test direct call to handler
+        handler = AstropyRegionsHandler()
+        reg_2 = handler.to_object(subset_state)
+        assert isinstance(reg_2, RectanglePixelRegion)
+        assert_allclose(reg_2.center.x, 2.25)
+        assert_allclose(reg_2.center.y, 1.55)
+        assert_allclose(reg_2.width, 2.5)
+        assert_allclose(reg_2.height, 3.5)
 
     def test_polygonal_roi(self):
 
@@ -313,7 +323,7 @@ class TestAstropyRegions:
         subset_state = _annulus_to_subset_state(reg_orig, self.data)
 
         # There is a new way to make annulus in newer glue.
-        if not GLUE_LT_1_10_1:
+        if not GLUE_LT_1_11:
             from glue.core.roi import CircularAnnulusROI
             assert (isinstance(subset_state, RoiSubsetState) and
                     isinstance(subset_state.roi, CircularAnnulusROI))


### PR DESCRIPTION
## Description

There is a need for Jdaviz to be able to call the translator code directly and have option to get back sky regions. The first part is useful for spatial region translations where we pass in the subset state directly internally and there is really no need to access `subset.data`. This blocks:

* https://github.com/spacetelescope/jdaviz/pull/2240
* spacetelescope/jdaviz#2250

Fix #89 

cc @dhomeier or @astrofrog 