### PR TITLE
allow override of wcs when computing sky region in roi_subset_state_to_region

### DIFF
--- a/glue_astronomy/translators/regions.py
+++ b/glue_astronomy/translators/regions.py
@@ -62,8 +62,8 @@ def roi_subset_state_to_region(subset_state, to_sky=False, override_wcs=None):
 
     Parameters
     ----------
-    subset_state : `glue.core.data.Data`
-        The 2D glue Data object on which the range subset is defined.
+    subset_state : `~glue.core.subset.SubsetState`
+        ROI subset state.
     to_sky: bool or WCS object
         If True, return region in celestial coordinates from attached data WCS.
         Optionally, if a WCS object - a world coordinate system (WCS)

--- a/glue_astronomy/translators/regions.py
+++ b/glue_astronomy/translators/regions.py
@@ -53,12 +53,24 @@ def range_to_rect(data, ori, low, high):
     return RectanglePixelRegion(PixCoord(xcen, ycen), width, height)
 
 
-def roi_subset_state_to_region(subset_state, to_sky=False):
+def roi_subset_state_to_region(subset_state, to_sky=False, override_wcs=None):
     """Translate the given ``RoiSubsetState`` containing ROI
     that is compatible with 2D spatial regions to proper
     ``regions`` shape. If ``to_sky=True`` is given, it will
     return sky region from attached data WCS, otherwise it returns
     pixel region.
+
+    Parameters
+    ----------
+    subset_state : `glue.core.data.Data`
+        The 2D glue Data object on which the range subset is defined.
+    to_sky: bool
+        Specifies if the range limits are for the x-axis or y-axis respectively.
+    override_wcs : WCS object
+        A world coordinate system (WCS) transformation that
+        supports the `astropy shared interface for WCS
+        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.,
+        `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
     """
     roi = subset_state.roi
 
@@ -93,7 +105,10 @@ def roi_subset_state_to_region(subset_state, to_sky=False):
         raise NotImplementedError(f"ROIs of type {roi.__class__.__name__} are not yet supported")
 
     if to_sky:
-        reg = reg.to_sky(subset_state.xatt.parent.coords)
+        if override_wcs is not None:
+            reg = reg.to_sky(override_wcs)
+        else:
+            reg = reg.to_sky(subset_state.xatt.parent.coords)
 
     return reg
 

--- a/glue_astronomy/translators/regions.py
+++ b/glue_astronomy/translators/regions.py
@@ -54,12 +54,16 @@ def range_to_rect(data, ori, low, high):
     return RectanglePixelRegion(PixCoord(xcen, ycen), width, height)
 
 
-def roi_subset_state_to_region(subset_state, to_sky=False, override_wcs=None):
+def roi_subset_state_to_region(subset_state, to_sky=False):
     """Translate the given ``RoiSubsetState`` containing ROI
     that is compatible with 2D spatial regions to proper
-    ``regions`` shape. If ``to_sky=True`` is given, it will
-    return sky region from attached data WCS, otherwise it returns
-    pixel region.
+    ``regions`` shape.
+
+    If ``to_sky`` is False, it will return the region in pixel coordinates.
+    If ``to_sky=True``, it will return the region transformed to sky
+    coordinates, per attached data WCS. Alternatively,  ``to_sky`` can be a WCS
+    object, which will override any WCS on the input subset state data and the
+    region will be returned in pixel coordinates.
 
     Parameters
     ----------
@@ -106,6 +110,8 @@ def roi_subset_state_to_region(subset_state, to_sky=False, override_wcs=None):
         raise NotImplementedError(f"ROIs of type {roi.__class__.__name__} are not yet supported")
 
     if to_sky is True:
+        if subset_state.xatt.parent.coords is None:
+            raise ValueError('Subset parent does not have a WCS.')
         reg = reg.to_sky(subset_state.xatt.parent.coords)
     elif isinstance(to_sky, BaseHighLevelWCS):
         reg = reg.to_sky(to_sky)

--- a/glue_astronomy/translators/regions.py
+++ b/glue_astronomy/translators/regions.py
@@ -64,13 +64,13 @@ def roi_subset_state_to_region(subset_state, to_sky=False, override_wcs=None):
     ----------
     subset_state : `glue.core.data.Data`
         The 2D glue Data object on which the range subset is defined.
-    to_sky: bool
-        Specifies if the range limits are for the x-axis or y-axis respectively.
-    override_wcs : WCS object
-        A world coordinate system (WCS) transformation that
-        supports the `astropy shared interface for WCS
-        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_ (e.g.,
-        `astropy.wcs.WCS`, `gwcs.wcs.WCS`).
+    to_sky: bool or WCS object
+        If True, return region in celestial coordinates from attached data WCS.
+        Optionally, if a WCS object - a world coordinate system (WCS)
+        transformation that supports the `astropy shared interface for WCS
+        <https://docs.astropy.org/en/stable/wcs/wcsapi.html>`_
+        (e.g., `astropy.wcs.WCS`, `gwcs.wcs.WCS`) - is provided, then this will
+        override the WCS attached to the subset data.
     """
     roi = subset_state.roi
 
@@ -104,12 +104,11 @@ def roi_subset_state_to_region(subset_state, to_sky=False, override_wcs=None):
     else:
         raise NotImplementedError(f"ROIs of type {roi.__class__.__name__} are not yet supported")
 
-    if to_sky:
-        if override_wcs is not None:
-            reg = reg.to_sky(override_wcs)
+    if to_sky:  # either True or WCS object
+        if isinstance(to_sky, bool):
+        	reg = reg.to_sky(subset_state.xatt.parent.coords)
         else:
-            reg = reg.to_sky(subset_state.xatt.parent.coords)
-
+            reg = reg.to_sky(to_sky)
     return reg
 
 

--- a/glue_astronomy/translators/regions.py
+++ b/glue_astronomy/translators/regions.py
@@ -7,6 +7,7 @@ from glue.viewers.image.pixel_selection_subset_state import PixelSubsetState
 from glue import __version__ as glue_version
 
 from astropy import units as u
+from astropy.wcs.wcsapi import BaseHighLevelWCS
 from packaging.version import Version
 from regions import (RectanglePixelRegion, PolygonPixelRegion, CirclePixelRegion,
                      PointPixelRegion, PixCoord, EllipsePixelRegion,
@@ -104,11 +105,10 @@ def roi_subset_state_to_region(subset_state, to_sky=False, override_wcs=None):
     else:
         raise NotImplementedError(f"ROIs of type {roi.__class__.__name__} are not yet supported")
 
-    if to_sky:  # either True or WCS object
-        if isinstance(to_sky, bool):
-        	reg = reg.to_sky(subset_state.xatt.parent.coords)
-        else:
-            reg = reg.to_sky(to_sky)
+    if to_sky is True:
+        reg = reg.to_sky(subset_state.xatt.parent.coords)
+    elif isinstance(to_sky, BaseHighLevelWCS):
+        reg = reg.to_sky(to_sky)
     return reg
 
 

--- a/glue_astronomy/translators/tests/test_regions.py
+++ b/glue_astronomy/translators/tests/test_regions.py
@@ -6,8 +6,8 @@ from astropy.tests.helper import assert_quantity_allclose
 from numpy.testing import assert_allclose, assert_array_equal, assert_equal
 from packaging.version import Version
 
-from regions import (RectanglePixelRegion, RectangleSkyRegion,
-                     PolygonPixelRegion, CirclePixelRegion,
+from regions import (RectanglePixelRegion, PolygonPixelRegion,
+                     CirclePixelRegion, CircleSkyRegion,
                      EllipsePixelRegion, PointPixelRegion, CompoundPixelRegion,
                      CircleAnnulusPixelRegion, PixCoord)
 
@@ -502,6 +502,7 @@ class TestAstropyRegions:
         assert_allclose(reg_sky.center.dec.deg, 4.48805907)
 
         # test overriding WCS
+
         override_wcs = WCS(naxis=2)
         override_wcs.wcs.ctype = ['RA---TAN', 'DEC--TAN']
         override_wcs.wcs.crval = [0, -90]


### PR DESCRIPTION
In JDaviz (Cubeviz, specifically), sometimes subsets don't contain spatial wcs information in subset.xatt.coords, which is what is used for the pixel-to-sky conversion in `roi_subset_state_to_region`. To fix this issue, this PR adds the option to provide a different WCS for the conversion, which will override anything in `.coords`. 

(See https://github.com/spacetelescope/jdaviz/pull/2496) 


