### PR TITLE
Add spectral_cube, glue-qt to devdeps; test py312

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
         - linux: py39-test
         - linux: py310-test-dev
         - linux: py311-test-dev
+        - linux: py312-test-dev
 
         - macos: py311-test
         - windows: py38-test

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311}-{test,docs,codestyle}-{dev}
+envlist = py{38,39,310,311,312}-{test,docs,codestyle}-{dev}
 requires = pip >= 18.0
            setuptools >= 30.3.0
 
@@ -9,10 +9,13 @@ passenv =
 changedir =
     docs: docs
 deps =
-    dev: git+https://github.com/astropy/astropy
-    dev: git+https://github.com/astropy/specutils
-    dev: git+https://github.com/astropy/regions
-    dev: git+https://github.com/glue-viz/glue
+    dev: git+https://github.com/astropy/astropy.git
+    dev: git+https://github.com/astropy/specutils.git
+    dev: git+https://github.com/astropy/regions.git
+    dev: git+https://github.com/glue-viz/glue.git
+    dev: git+https://github.com/glue-viz/glue-qt.git
+    dev: git+https://github.com/radio-astro-tools/spectral-cube.git
+    dev: git+https://github.com/radio-astro-tools/radio-beam.git
 extras =
     test: test
     docs: docs


### PR DESCRIPTION
## Description
Astropy 6.0dev has removed a number of deprecated functions, breaking CI through spectral_cube, with a fix merged, but not released. Adding it to the git-installs for `dev` at least temporarily, and also adding glue-qt to keep sync'ed with glue-core. Finally throwing in a py312 test job.