### PR TITLE
Loosen check on coordinate class for NDData translator to accept subclasses

### DIFF
--- a/glue_astronomy/translators/nddata.py
+++ b/glue_astronomy/translators/nddata.py
@@ -77,7 +77,7 @@ class NDDataArrayHandler:
 
         if isinstance(data.coords, (WCS, BaseHighLevelWCS, SpectralCoordinates)):
             wcs = data.coords
-        elif type(data.coords) is Coordinates or data.coords is None:
+        elif isinstance(data.coords, Coordinates) or data.coords is None:
             wcs = None
         else:
             raise TypeError('data.coords should be an instance of Coordinates or WCS')

--- a/glue_astronomy/translators/tests/test_nddata.py
+++ b/glue_astronomy/translators/tests/test_nddata.py
@@ -11,7 +11,7 @@ from astropy.wcs import WCS
 
 from glue.core import Data, DataCollection
 from glue.core.component import Component
-from glue.core.coordinates import Coordinates
+from glue.core.coordinates import Coordinates, IdentityCoordinates
 
 WCS_CELESTIAL = WCS(naxis=2)
 WCS_CELESTIAL.wcs.ctype = ['RA---TAN', 'DEC--TAN']
@@ -222,3 +222,17 @@ def test_meta_round_trip():
         assert len(image_new.meta) == 2
         assert image_new.meta['BUNIT'] == 'Jy/beam'
         assert image_new.meta['some_variable'] == 10
+
+
+def test_other_coords():
+    coords = IdentityCoordinates(n_dim=2)
+
+    flux = [[2, 3], [4, 5]] * u.Jy
+    ndd = NDDataArray(data=flux)
+
+    data_collection = DataCollection()
+
+    data_collection['image'] = ndd
+    data_collection['image'].coords = coords
+    round_trip_ndd = data_collection['image'].get_object(cls=NDDataArray)
+    assert round_trip_ndd.shape == (2, 2)


### PR DESCRIPTION
The NDData translator checks that the `Data.coords` is either a WCS object, a glue `Coordinates` object, or None. Other Coordinates types are not allowed in the current logic. I'm trying to work with a case where the coordinate attribute that's an `IdentityCoordinate`, but that's disallowed. 

This PR simply allows `coords` attributes that are subclasses of Coordinates.