### PR TITLE
Update test_trace to specreduce 1.4 interface

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,14 +35,16 @@ jobs:
         # Standard tests
         - linux: py38-test
         - linux: py39-test
+        - linux: py312-test
         - linux: py310-test-dev
         - linux: py311-test-dev
         - linux: py312-test-dev
 
         - macos: py311-test
+        - macos: py312-test-dev
+
         - windows: py38-test
-        - windows: py39-test-dev
-        - macos: py310-test-dev
+        - windows: py311-test-dev
 
   publish:
     needs: tests

--- a/glue_astronomy/translators/tests/test_trace.py
+++ b/glue_astronomy/translators/tests/test_trace.py
@@ -1,14 +1,21 @@
 import numpy as np
 
 from specreduce import tracing
-from specreduce.utils.synth_data import make_2dspec_image
+
+# renamed in specreduce 1.4 and `add_noise` option added (requires photutils)
+try:
+    from specreduce.utils.synth_data import make_2d_trace_image
+    trace_args = dict(add_noise=False)
+except ImportError:
+    from specreduce.utils.synth_data import make_2dspec_image as make_2d_trace_image
+    trace_args = dict()
 
 from glue.core import Data, DataCollection
 
 
 def test_trace():
 
-    image = make_2dspec_image()
+    image = make_2d_trace_image(**trace_args)
     trace = tracing.FlatTrace(image, 5)
 
     data_collection = DataCollection()


### PR DESCRIPTION
## Description
Function name has been changed in astropy/specreduce#165. This has also introduced a new, default-True option `add_noise`, which requires `photutils`. I suppose it is not of interest for the functionality tested here, or should I add `photutils` to test-deps and use the default?