### PR TITLE
Add pre-commit and test configuration for ruff codestyle checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,53 @@
+ci:
+  autofix_prs: false
+  autoupdate_schedule: 'monthly'
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--enforce-all", "--maxkb=300"]
+        # Prevent giant files from being committed.
+      - id: check-case-conflict
+        # Check for files with names that would conflict on a case-insensitive
+        # filesystem like MacOS HFS+ or Windows FAT.
+      - id: check-json
+        # Attempts to load all json files to verify syntax.
+      - id: check-merge-conflict
+        # Check for files that contain merge conflict strings.
+      - id: check-symlinks
+        # Checks for symlinks which do not point to anything.
+      - id: check-toml
+        # Attempts to load all TOML files to verify syntax.
+      - id: check-xml
+        # Attempts to load all xml files to verify syntax.
+      - id: check-yaml
+        # Attempts to load all yaml files to verify syntax.
+        exclude: ".*(.github.*)$"
+      - id: detect-private-key
+        # Checks for the existence of private keys.
+      - id: end-of-file-fixer
+        # Makes sure files end in a newline and only a newline.
+        exclude: ".*(table.info|table.f0_TSM0)$"
+      # - id: fix-encoding-pragma  # covered by pyupgrade
+      - id: trailing-whitespace
+        # Trims trailing whitespace.
+        exclude_types: [python]  # Covered by Ruff W291.
+        exclude: ".*(table.info)$"
+
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.10.0
+    hooks:
+      - id: rst-directive-colons
+        # Detect mistake of rst directive not ending with double colon.
+      - id: rst-inline-touching-normal
+        # Detect mistake of inline code touching normal text in rst.
+      - id: text-unicode-replacement-char
+        # Forbid files which have a UTF-8 Unicode replacement character.
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.12.2"
+    hooks:
+      - id: ruff
+        args: ["--fix", "--show-fixes"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         # Forbid files which have a UTF-8 Unicode replacement character.
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.12.2"
+    rev: "v0.12.7"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,119 @@
+extend = "pyproject.toml"
+lint.ignore = [
+    # NOTE: to find a good code to fix, run:
+    # ruff check --select="ALL" --statistics glue_qt/<subpackage>
+
+    # flake8-unused-arguments (ARG)
+    "ARG001",  # unused-function-argument
+    "ARG002",  # unused-method-argument
+
+    # flake8-comprehensions (C4)
+    "C408",  # Unnecessary `dict()` call (rewrite as a literal)
+    "C409",  # Unnecessary list literal passed to `tuple()` (rewrite as a set comprehension)
+    "C419",  # Unnecessary list comprehension
+
+    # pydocstyle (D)
+    # Missing Docstrings
+    "D100",  # undocumented-public-module
+    "D101",  # undocumented-public-class
+    "D103",  # undocumented-public-function
+    "D104",  # undocumented-public-package
+    "D202",  # blank-line-after-function
+    "D205",  # blank-line-after-summary
+
+    # pycodestyle (E, W)
+    "E501",  # line-too-long
+
+    # flake8-errmsg (EM)  : nicer error tracebacks
+    "EM101",   # raw-string-in-exception
+    "EM102",   # f-string-in-exception
+
+    # eradicate (ERA)
+    # NOTE: be careful that developer notes are kept.
+    "ERA001",  # commented-out-code
+
+    # isort (I)
+    "I001",  # unsorted imports
+
+    # NumPy-specific rules (NPY)
+    "NPY002", # Replace legacy `np.random.rand` call with `np.random.Generator`  (2023-05-03)
+
+    # pygrep-hooks (PGH)
+    "PGH004",  # Use specific rule codes when using `noqa`
+
+    # flake8-pie (PIE)
+    "PIE808",  # Unnecessary `start` argument in `range`
+
+    # Pylint (PLC, PLE, PLR, PLW)
+    "PLR0911",  # too-many-return-statements (12 > 6)
+    "PLR0912",  # too-many-branches
+    "PLR0915",  # too-many-statements
+    "PLR2004",  # MagicValueComparison
+
+    # flake8-pytest-style (PT)
+    "PT006",   # pytest-parametrize-names-wrong-type
+    "PT007",   # pytest-parametrize-values-wrong-type
+    "PT011",   # pytest-raises-too-broad
+    "PT012",   # pytest-raises-with-multiple-statements
+    "PT018",   # pytest-composite-assertion
+
+    # flake8-use-pathlib (PTH)
+    "PTH110",  # os-path-exists
+    "PTH112",  # os-path-isdir
+    "PTH118",  # os-path-join
+    "PTH120",  # os-path-dirname
+
+    # flake8-quotes (Q)
+    "Q000",    # Single quotes found but double quotes preferred
+
+    # flake8-return (RET)
+    "RET504",  # unnecessary-assign
+    "RET505",  # unnecessary-else-after-return
+
+    # flake8-raise (RSE)
+    "RSE102",  # unnecessary-paren-on-raise-exception
+
+    # Ruff-specific rules (RUF)
+    "RUF022",  # `__all__` is not sorted
+    "RUF100",  # Unused blanket `noqa` directive
+
+    # flake8-bandit (S)
+    "S101",  # Use of `assert` detected
+
+    # flake8-simplify (SIM)
+    "SIM108",  # UseTernaryOperator
+
+    # flake8-print (T20)
+    "T201",  # PrintUsed
+
+    # flake8-todos (TD)
+    "TD003",  # Missing issue link on the line following this TODO
+
+    # tryceratops (TRY)
+    "TRY003",  # raise-vanilla-args
+]
+lint.unfixable = []
+
+[lint.extend-per-file-ignores]
+"__init__.py" = ["E402", "F401", "F403", "PT013"]
+".github/workflows/check_failures.py" = ["ICN001", "S314"]
+"test_*.py" = ["B015", "RUF015"]  # Pointless comparison; prefer next({iterable}) over slice
+
+# pyupgrade (UP) - UP009: UTF-8 encoding declaration is unnecessary (1); UP025: Remove unicode literals from strings (8)
+"docs/conf.py" = ["UP009", "UP025"]
+
+# flake8-blind-except (BLE001)
+# Pylint collapsible-else-if (PLR5501)
+"glue_astronomy/io/spectral_cube/spectral_cube.py" = ["BLE001", "PLR5501"]
+
+# flake8-bugbear (B904): RaiseWithoutFromInsideExcept
+# mccabe (C90): code complexity
+# TODO: configure maximum mccabe allowed complexity (default 10; 2 exceptions @20, 32).
+# flake8-boolean-trap (FBT): Boolean default positional argument in function definition
+#     NOTE: a good thing to fix, but changes API.
+# tryceratops (TRY004): prefer-type-error
+"glue_astronomy/translators/regions.py" = ["B904", "C901", "FBT002", "TRY004"]
+
+# mccabe (C90) : code complexity
+# Perflint (PERF401): Use a list comprehension to create a transformed list
+"glue_astronomy/translators/spectrum1d.py" = ["C901", "PERF401"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -22,7 +22,6 @@ lint.ignore = [
     "D205",  # blank-line-after-summary
 
     # pycodestyle (E, W)
-    "E501",  # line-too-long
 
     # flake8-errmsg (EM)  : nicer error tracebacks
     "EM101",   # raw-string-in-exception

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -145,9 +145,9 @@
 
 - Updated `AstropyRegions` translator to export `roi.theta` angle
 - (supported as of `glue` 1.5.0). in https://github.com/glue-viz/glue-astronomy/pull/73
-- 
+-
 - Added support to import and export `specreduce` `Trace` objects. in https://github.com/glue-viz/glue-astronomy/pull/72
-- 
+-
 
 ## [0.4.0](https://github.com/glue-viz/glue-astronomy/compare/v0.3.3...v0.4.0) - 2022-04-07
 
@@ -165,9 +165,9 @@
 
 - Fixed translation to `regions.EllipsePixelRegion`. Previous translation
 - was passing in radii as full height/width of the ellipse. in https://github.com/glue-viz/glue-astronomy/pull/67
-- 
+-
 - Fixed compatibility of CCDData translator with GWCS. in https://github.com/glue-viz/glue-astronomy/pull/58
-- 
+-
 
 ## [0.3.2](https://github.com/glue-viz/glue-astronomy/compare/v0.3.1...v0.3.2) - 2021-09-14
 

--- a/glue_astronomy/io/spectral_cube/spectral_cube.py
+++ b/glue_astronomy/io/spectral_cube/spectral_cube.py
@@ -27,9 +27,7 @@ def identify_file_format(filename):
 
 
 def is_spectral_cube(filename, **kwargs):
-    """
-    Check that the file is a 3D or 4D FITS spectral cube
-    """
+    """Check that the file is a 3D or 4D FITS spectral cube"""
 
     file_format = identify_file_format(filename)
 
@@ -54,7 +52,7 @@ def spectral_cube_to_data(cube, label=None):
 
     for component in cube.components:
         data = getattr(cube, component)._data
-        result.add_component(data, label='STOKES {0}'.format(component))
+        result.add_component(data, label=f'STOKES {component}')
 
     result._preferred_translation = SpectralCube
 

--- a/glue_astronomy/spectral_coordinates.py
+++ b/glue_astronomy/spectral_coordinates.py
@@ -8,7 +8,7 @@ __all__ = ['SpectralCoordinates']
 
 class SpectralCoordinates(Coordinates):
     """
-    This is a sub-class of Coordinates that is intended for 1-d spectral axes
+    Subclass of Coordinates that is intended for 1-d spectral axes
     given by a :class:`~astropy.units.Quantity` array.
     """
 

--- a/glue_astronomy/translators/regions.py
+++ b/glue_astronomy/translators/regions.py
@@ -19,7 +19,7 @@ GLUE_LT_1_11 = Version(glue_version) < Version('1.11')
 
 def range_to_rect(data, ori, low, high):
     """
-    Converts a 1D range on a 2D glue Data set into an astropy regions RectangularPixelRegion.
+    Convert a 1D range on a 2D glue Data set into an astropy regions RectangularPixelRegion.
 
     The region covers the entirety of the data along the axis not specified by the `ori` parameter.
 

--- a/glue_astronomy/translators/spectral_cube.py
+++ b/glue_astronomy/translators/spectral_cube.py
@@ -34,7 +34,7 @@ class SpectralCubeHandler:
             The attribute to use for the SpectralCube data
         """
 
-        if data_or_subset.ndim > 0 and data_or_subset.ndim != 3 and data_or_subset.ndim != 4:
+        if data_or_subset.ndim > 0 and data_or_subset.ndim not in {3, 4}:
             raise ValueError('Data object should have 3 or 4 dimensions in order to '
                              'be converted to a SpectralCube object.')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,64 @@ requires = ["setuptools>=30.3.0",
             "setuptools_scm",
             "wheel"]
 build-backend = 'setuptools.build_meta'
+
+[tool.ruff]
+# ruff check: pycodestyle, Pyflakes, McCabe, flake8-bugbear, flake8-simplify
+lint.select = ["ALL"]
+lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml` instead.
+
+    # flake8-builtins (A) : shadowing a Python built-in.
+    # New ones should be avoided and is up to maintainers to enforce.
+
+    # flake8-commas (COM)
+    "COM812",  # TrailingCommaMissing
+
+    # pydocstyle (D)
+    # Missing Docstrings
+    "D102",  # Missing docstring in public method. Don't check b/c docstring inheritance.
+    # Docstring Content Issues
+    "D400",  # EndsInPeriod.  NOTE: might want to revisit this.
+    "D410",  # BlankLineAfterSection. Using D412 instead.
+    "D411",  # BlankLineBeforeSection.
+    "D414",  # EmptyDocstringSection.
+
+    # flake8-fixme (FIX)
+    "FIX002",  # Line contains TODO | notes for improvements are OK if the code works
+
+    # Pylint (PLC, PLE, PLR, PLW)
+    "PLC0415",  # `import` should be at the top-level of a file
+
+    # flake8-self (SLF)
+    "SLF001", # private member access
+
+    # flake8-todos (TD)
+    "TD002",  # Missing author in TODO
+]
+
+[tool.ruff.lint.extend-per-file-ignores]
+"setup.py" = ["INP001"]  # Part of configuration, not a package.
+".github/workflows/*.py" = ["INP001"]
+"test_*.py" = [
+    "D",  # pydocstyle
+]
+"docs/conf*.py" = [
+    "A001",  # Variable `copyright` is shadowing a Python builtin.
+    "INP001",  # implicit-namespace-package. The examples are not a package.
+    "COM819",  # Trailing comma prohibited.
+]
+
+[tool.ruff.lint.flake8-annotations]
+ignore-fully-untyped = true
+mypy-init-return = true
+
+[tool.ruff.lint.flake8-comprehensions]
+allow-dict-calls-with-keyword-arguments = true
+
+[tool.ruff.lint.flake8-type-checking]
+exempt-modules = []
+
+[tool.ruff.lint.isort]
+known-first-party = ["glue", "glue_astronomy"]
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ requires = ["setuptools>=30.3.0",
 build-backend = 'setuptools.build_meta'
 
 [tool.ruff]
+line-length = 100
 # ruff check: pycodestyle, Pyflakes, McCabe, flake8-bugbear, flake8-simplify
 lint.select = ["ALL"]
 lint.ignore = [  # NOTE: non-permanent exclusions should be added to `.ruff.toml` instead.

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,10 @@ commands =
     docs: sphinx-build -W -b html -d _build/doctrees   . _build/html
 
 [testenv:codestyle]
-deps = flake8
 skip_install = true
+description = Run all style and file checks with pre-commit
+deps =
+    pre-commit
 commands =
-    flake8 glue_astronomy
+    pre-commit install-hooks
+    pre-commit run --color always --all-files --show-diff-on-failure


### PR DESCRIPTION
## Description
Adding basic configuration for ruff codestyle, but not format checks along the lines of glue-viz/glue-qt#31 – see also there for documentation:

1. temporary exceptions listed in `.ruff.toml`
2. (more) permanent exceptions in `pyproject.toml`
3. some straightforward fixes in the files in the second commit